### PR TITLE
make tool name configurable

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -39,6 +39,8 @@ func mainfunc(cmd *cobra.Command, args []string) {
 
 	eventChan := make(chan types.Entry, defaultQueueSize)
 
+	util.ToolName = viper.GetString("toolname")
+
 	logfilename := viper.GetString("logging.file")
 	if len(logfilename) > 0 {
 		log.Println("Switching to log file", logfilename)
@@ -474,6 +476,8 @@ func init() {
 	viper.BindPFlag("flushtime", runCmd.PersistentFlags().Lookup("flushtime"))
 	runCmd.PersistentFlags().UintP("flushcount", "", 100000, "maximum number of events in one batch (e.g. for flow extraction)")
 	viper.BindPFlag("flushcount", runCmd.PersistentFlags().Lookup("flushcount"))
+	runCmd.PersistentFlags().StringP("toolname", "", "fever", "set toolname")
+	viper.BindPFlag("toolname", runCmd.PersistentFlags().Lookup("toolname"))
 
 	// Database options
 	runCmd.PersistentFlags().BoolP("db-enable", "", false, "write events to database")

--- a/processing/handler_dispatcher_test.go
+++ b/processing/handler_dispatcher_test.go
@@ -236,7 +236,7 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 	if len(results) == 0 {
 		t.Fatalf("unexpected result length: %d == 0", len(results))
 	}
-	if match, _ := regexp.Match("^fever,[^ ]+ dispatch_calls_per_sec=[0-2]", []byte(results[0])); !match {
+	if match, _ := regexp.Match(fmt.Sprintf("^%s,[^ ]+ dispatch_calls_per_sec=[0-2]", util.ToolName), []byte(results[0])); !match {
 		t.Fatalf("unexpected match content: %s", results[0])
 	}
 	resultsLock.Unlock()

--- a/util/performance_stats_encoder_test.go
+++ b/util/performance_stats_encoder_test.go
@@ -4,6 +4,7 @@ package util
 // Copyright (c) 2017, DCSO GmbH
 
 import (
+	"fmt"
 	"regexp"
 	"sync"
 	"testing"
@@ -132,16 +133,16 @@ func TestPerformanceStatsEncoder(t *testing.T) {
 	if len(results) != 4 {
 		t.Fatalf("unexpected result length: %d != 4", len(results))
 	}
-	if match, _ := regexp.Match("^fever,[^ ]+ testval=1i,testvalue=2i", []byte(results[0])); !match {
+	if match, _ := regexp.Match(fmt.Sprintf("^%s,[^ ]+ testval=1i,testvalue=2i", ToolName), []byte(results[0])); !match {
 		t.Fatalf("unexpected match content: %s", results[0])
 	}
-	if match, _ := regexp.Match("^fever,[^ ]+ testval=1i,testvalue=2i", []byte(results[1])); !match {
+	if match, _ := regexp.Match(fmt.Sprintf("^%s,[^ ]+ testval=1i,testvalue=2i", ToolName), []byte(results[1])); !match {
 		t.Fatalf("unexpected match content: %s", results[1])
 	}
-	if match, _ := regexp.Match("^fever,[^ ]+ testval=3i,testvalue=2i", []byte(results[2])); !match {
+	if match, _ := regexp.Match(fmt.Sprintf("^%s,[^ ]+ testval=3i,testvalue=2i", ToolName), []byte(results[2])); !match {
 		t.Fatalf("unexpected match content: %s", results[2])
 	}
-	if match, _ := regexp.Match("^fever,[^ ]+ testval=3i,testvalue=2i", []byte(results[3])); !match {
+	if match, _ := regexp.Match(fmt.Sprintf("^%s,[^ ]+ testval=3i,testvalue=2i", ToolName), []byte(results[3])); !match {
 		t.Fatalf("unexpected match content: %s", results[3])
 	}
 	resultsLock.Unlock()


### PR DESCRIPTION
One might imagine situations where the tool name, as it is mentioned in InfluxDB measurement names, for instance, might need to be set to a fixed value for legacy reasons. This PR introduces a new option, `--toolname`, which allows to override the default tool name of 'fever'.