### PR TITLE
minor cleanups and fixes

### DIFF
--- a/fever.yaml
+++ b/fever.yaml
@@ -60,7 +60,7 @@ flowreport:
   # Interval used for aggregation.
   interval: 60s
   submission-url: amqp://guest:guest@localhost:5672/
-  exchange: aggregations
+  submission-exchange: aggregations
   # Set to true to disable gzip compression for uploads.
   nocompress: false
 
@@ -68,19 +68,19 @@ flowreport:
 metrics:
   enable: true
   submission-url: amqp://guest:guest@localhost:5672/
-  exchange: metrics
+  submission-exchange: metrics
 
 # Configuration for passive DNS submission.
 pdns:
   enable: true
   submission-url: amqp://guest:guest@localhost:5672/
-  exchange: pdns
+  submission-exchange: pdns
 
 # Configuration for detailed flow metadata submission.
 flowextract:
   enable: false
   submission-url: amqp://guest:guest@localhost:5672/
-  exchange: aggregations
+  submission-exchange: aggregations
   # Uncomment to enable flow collection only for IPs in the given 
   # Bloom filter.
   #  bloom-selector: /tmp/flows.bloom

--- a/input/input_redis.go
+++ b/input/input_redis.go
@@ -246,7 +246,7 @@ func MakeRedisInput(addr string, outChan chan types.Entry, batchSize int) (*Redi
 				if err != nil {
 					return nil, err
 				}
-				log.Info("Dialing %s... %b", addr, err != nil)
+				log.Infof("Dialing %s... result: %v", addr, err == nil)
 				return c, err
 			},
 			TestOnBorrow: func(c redis.Conn, t time.Time) error {
@@ -255,7 +255,6 @@ func MakeRedisInput(addr string, outChan chan types.Entry, batchSize int) (*Redi
 			},
 		},
 	}
-	log.Debug("created pool ", ri.Pool)
 	return ri, err
 }
 
@@ -279,7 +278,7 @@ func MakeRedisInputSocket(addr string, outChan chan types.Entry, batchSize int) 
 				if err != nil {
 					return nil, err
 				}
-				log.Info("Dialing %s... %v", addr, err == nil)
+				log.Infof("Dialing %s... result: %v", addr, err == nil)
 				return c, err
 			},
 			TestOnBorrow: func(c redis.Conn, t time.Time) error {
@@ -291,7 +290,6 @@ func MakeRedisInputSocket(addr string, outChan chan types.Entry, batchSize int) 
 			},
 		},
 	}
-	log.Debug("created pool ", ri.Pool)
 	return ri, err
 }
 


### PR DESCRIPTION
This PR addresses the following points:
- Use of the correct `submission-exchange` key instead of `exchange` in the YAML config file example
- Sensibel formatting of log output for the Redis input