### PR TITLE
fix remaining issues breaking CI

### DIFF
--- a/processing/flow_extractor_test.go
+++ b/processing/flow_extractor_test.go
@@ -51,9 +51,9 @@ func makeFlowExtractorEvent(ipv6 bool) types.Entry {
 	return e
 }
 
-func makeBloomFilter(n int) *bloom.BloomFilter {
-	bf := bloom.Initialize(uint32(n), 1e-10)
-	for i := 0; i < n; i++ {
+func makeBloomFilter() *bloom.BloomFilter {
+	bf := bloom.Initialize(10000, 1e-10)
+	for i := 0; i < 10000; i++ {
 		bf.Add([]byte(fmt.Sprintf("10.0.0.%d", rand.Intn(50))))
 	}
 	bf.Add([]byte("2001:0db8:85a3:0000:0000:8a2e:0370:7334"))
@@ -98,7 +98,7 @@ func TestFlowExtractor(t *testing.T) {
 
 	mla, err := MakeFlowExtractor(2*time.Second, 100, "", submitter)
 
-	mla.BloomFilter = makeBloomFilter(nEvents)
+	mla.BloomFilter = makeBloomFilter()
 
 	if err != nil {
 		t.Fatal(err)

--- a/processing/handler_dispatcher_test.go
+++ b/processing/handler_dispatcher_test.go
@@ -182,7 +182,6 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Shutdown()
 
 	// set up submitter
 	statssubmitter, err := util.MakeAMQPSubmitterWithReconnector(serverURL,
@@ -231,6 +230,8 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 	stopChan := make(chan bool)
 	ad.Stop(stopChan)
 	<-stopChan
+
+	c.Shutdown()
 
 	resultsLock.Lock()
 	if len(results) == 0 {

--- a/processing/handler_dispatcher_test.go
+++ b/processing/handler_dispatcher_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
-	"sync"
 	"testing"
 	"time"
 
@@ -172,12 +171,9 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 
 	// set up consumer
 	results := make([]string, 0)
-	var resultsLock sync.Mutex
 	c, err := util.NewConsumer(serverURL, "nsm.test.metrics", "direct", "nsm.test.metrics.testqueue",
 		"", "", func(d wabbit.Delivery) {
-			resultsLock.Lock()
 			results = append(results, string(d.Body()))
-			resultsLock.Unlock()
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -233,12 +229,10 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 
 	c.Shutdown()
 
-	resultsLock.Lock()
 	if len(results) == 0 {
 		t.Fatalf("unexpected result length: %d == 0", len(results))
 	}
 	if match, _ := regexp.Match("^fever,[^ ]+ dispatch_calls_per_sec=[0-2]", []byte(results[0])); !match {
 		t.Fatalf("unexpected match content: %s", results[0])
 	}
-	resultsLock.Unlock()
 }


### PR DESCRIPTION
This MR adds a preliminary fix for the issue that the `bloom.Initialize()` method has had an API change.
It also addresses a concurrency problem with the handler dispatcher tests.