### PR TITLE
do not fail when no config file can be read

### DIFF
--- a/cmd/fever/cmds/root.go
+++ b/cmd/fever/cmds/root.go
@@ -64,7 +64,5 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		log.Infof("Using config file: %s", viper.ConfigFileUsed())
-	} else {
-		log.Fatalf("Error reading config file: %s", err)
 	}
 }


### PR DESCRIPTION
In this case we would want to fall back to defaults.