### PR TITLE
do not make empty Bloom filter file fatal

### DIFF
--- a/processing/bloom_handler.go
+++ b/processing/bloom_handler.go
@@ -5,7 +5,6 @@ package processing
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -138,9 +137,12 @@ func MakeBloomHandlerFromFile(bloomFilename string, compressed bool,
 	iocBloom, err := bloom.LoadFilter(bloomFilename, compressed)
 	if err != nil {
 		if err == io.EOF {
-			return nil, errors.New("file is empty")
+			log.Warnf("file is empty, using empty default one")
+			myBloom := bloom.Initialize(100, 0.00000001)
+			iocBloom = &myBloom
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 	bh := MakeBloomHandler(iocBloom, databaseChan, forwardHandler)
 	bh.BloomFilename = bloomFilename

--- a/processing/bloom_handler_test.go
+++ b/processing/bloom_handler_test.go
@@ -441,13 +441,11 @@ func TestBloomHandlerEmptyInput(t *testing.T) {
 	dbChan := make(chan types.Entry, 10)
 	defer close(dbChan)
 
-	_, err = MakeBloomHandlerFromFile(blFile.Name(), false, dbChan, nil)
-	if err == nil {
-		t.Fatal("error expected")
+	bf, err := MakeBloomHandlerFromFile(blFile.Name(), false, dbChan, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err.Error() != "file is empty" {
-		t.Fatalf("wrong error message: %s (expected \"file is empty\")",
-			err.Error())
+	if bf == nil {
+		t.Fatal("bloom filter should not be nil for empty file")
 	}
-
 }


### PR DESCRIPTION
In this case, we will substitute an empty filter, with the option to reload a proper one later.
Closes #15 