### PR TITLE
add IP blacklist alerting feature

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -199,6 +199,17 @@ func mainfunc(cmd *cobra.Command, args []string) {
 		dispatcher.RegisterHandler(bloomHandler)
 	}
 
+	ipFilePath := viper.GetString("ip.blacklist")
+	ipAlertPrefix := viper.GetString("ip.alert-prefix")
+	var ipHandler *processing.IPHandler
+	if ipFilePath != "" {
+		ipHandler, err = processing.MakeIPHandlerFromFile(ipFilePath, eventChan, forwardHandler, ipAlertPrefix)
+		if err != nil {
+			log.Fatal(err)
+		}
+		dispatcher.RegisterHandler(ipHandler)
+	}
+
 	// flow aggregation setup
 	flushPeriod := viper.GetDuration("flushtime")
 	log.Debugf("flushtime set to %v", flushPeriod)
@@ -531,6 +542,12 @@ func init() {
 	viper.BindPFlag("bloom.zipped", runCmd.PersistentFlags().Lookup("bloom-zipped"))
 	runCmd.PersistentFlags().StringP("bloom-alert-prefix", "", "BLF", "String prefix for Bloom filter alerts")
 	viper.BindPFlag("bloom.alert-prefix", runCmd.PersistentFlags().Lookup("bloom-alert-prefix"))
+
+	// IP blacklist alerting options
+	runCmd.PersistentFlags().StringP("ip-blacklist", "", "", "List with IP ranges to alert on")
+	viper.BindPFlag("ip.blacklist", runCmd.PersistentFlags().Lookup("ip-blacklist"))
+	runCmd.PersistentFlags().StringP("ip-alert-prefix", "", "IP-BLACKLIST", "String prefix for IP blacklist alerts")
+	viper.BindPFlag("ip.alert-prefix", runCmd.PersistentFlags().Lookup("ip-alert-prefix"))
 
 	// Flow extraction options
 	runCmd.PersistentFlags().BoolP("flowextract-enable", "", false, "extract and forward flow metadata")

--- a/db/slurper_ejdb.go
+++ b/db/slurper_ejdb.go
@@ -3,8 +3,8 @@
 package db
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/mkilling/goejdb"
+	log "github.com/sirupsen/logrus"
 )
 
 // EJDBSlurper is a Slurper that stores events in an EJDB database.

--- a/processing/bloom_handler_test.go
+++ b/processing/bloom_handler_test.go
@@ -212,7 +212,7 @@ func (h *CollectorHandler) Consume(e *types.Entry) error {
 }
 
 func TestBloomHandler(t *testing.T) {
-	// make sure that alers are forwarded
+	// make sure that alerts are forwarded
 	util.PrepareEventFilter([]string{"alert"}, false)
 
 	// initalize Bloom filter and fill with 'interesting' values

--- a/processing/event_profiler.go
+++ b/processing/event_profiler.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/DCSO/fever/types"
 	"github.com/DCSO/fever/util"
+	log "github.com/sirupsen/logrus"
 )
 
 // EventProfile contains counts per event_type such as occurrences and

--- a/processing/ip_handler.go
+++ b/processing/ip_handler.go
@@ -1,0 +1,190 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2018, DCSO GmbH
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/yl2chen/cidranger"
+)
+
+// MakeIPAlertEntryForHit returns an alert Entry as raised by an external
+// IP hit. The resulting alert will retain
+// the triggering event's metadata as well as
+// its timestamp.
+func MakeIPAlertEntryForHit(e types.Entry, matchedIP string,
+	rangerEntry cidranger.RangerEntry, alertPrefix string) types.Entry {
+	var eve types.EveEvent
+	var newEve types.EveEvent
+	var err = json.Unmarshal([]byte(e.JSONLine), &eve)
+	if err != nil {
+		log.Warn(err, e.JSONLine)
+	} else {
+		sig := "%s Communication involving IP %s in listed range %s"
+		matchedNet := rangerEntry.Network()
+		matchedNetString := matchedNet.String()
+		newEve = types.EveEvent{
+			EventType: "alert",
+			Alert: &types.AlertEvent{
+				Action:    "allowed",
+				Category:  "Potentially Bad Traffic",
+				Signature: fmt.Sprintf(sig, alertPrefix, matchedIP, matchedNetString),
+			},
+			Stream:     eve.Stream,
+			InIface:    eve.InIface,
+			SrcIP:      eve.SrcIP,
+			SrcPort:    eve.SrcPort,
+			DestIP:     eve.DestIP,
+			DestPort:   eve.DestPort,
+			Proto:      eve.Proto,
+			TxID:       eve.TxID,
+			Timestamp:  eve.Timestamp,
+			PacketInfo: eve.PacketInfo,
+			HTTP:       eve.HTTP,
+			DNS:        eve.DNS,
+			Flow:       eve.Flow,
+			SMTP:       eve.SMTP,
+			SSH:        eve.SSH,
+			Email:      eve.Email,
+			TLS:        eve.TLS,
+		}
+	}
+	newEntry := e
+	json, err := json.Marshal(newEve)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		newEntry.JSONLine = string(json)
+	}
+	newEntry.EventType = "alert"
+
+	return newEntry
+}
+
+// IPHandler is a Handler which is meant to check for the presence of
+// event type-specific keywords in a Bloom filter, raising new 'alert' type
+// events when matches are found.
+type IPHandler struct {
+	sync.Mutex
+	Logger            *log.Entry
+	Name              string
+	EventType         string
+	Ranger            cidranger.Ranger
+	IPListFilename    string
+	DatabaseEventChan chan types.Entry
+	ForwardHandler    Handler
+	DoForwardAlert    bool
+	AlertPrefix       string
+}
+
+// MakeIPHandler returns a new IPHandler, checking against the given
+// IP ranges and sending alerts to databaseChan as well as forwarding them
+// to a given forwarding handler.
+func MakeIPHandler(ranger cidranger.Ranger,
+	databaseChan chan types.Entry, forwardHandler Handler, alertPrefix string) *IPHandler {
+	bh := &IPHandler{
+		Logger: log.WithFields(log.Fields{
+			"domain": "ip-blacklist",
+		}),
+		Ranger:            ranger,
+		DatabaseEventChan: databaseChan,
+		ForwardHandler:    forwardHandler,
+		DoForwardAlert:    (util.ForwardAllEvents || util.AllowType("alert")),
+		AlertPrefix:       alertPrefix,
+	}
+	log.WithFields(log.Fields{}).Info("IP range list loaded")
+	return bh
+}
+
+func rangerFromFile(IPListFilename string) (cidranger.Ranger, error) {
+	inFile, err := os.Open(IPListFilename)
+	if err != nil {
+		return nil, err
+	}
+	defer inFile.Close()
+	ranger := cidranger.NewPCTrieRanger()
+	scanner := bufio.NewScanner(inFile)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		lineText := scanner.Text()
+		_, network, err := net.ParseCIDR(lineText)
+		if err != nil {
+			log.Warnf("invalid IP range %s, skipping", lineText)
+		} else {
+			log.Debugf("adding IP range %s", lineText)
+			ranger.Insert(cidranger.NewBasicRangerEntry(*network))
+		}
+	}
+	return ranger, nil
+}
+
+// MakeIPHandlerFromFile returns a new IPHandler created from a new
+// IP range list specified by the given file name.
+func MakeIPHandlerFromFile(IPListFilename string,
+	databaseChan chan types.Entry, forwardHandler Handler, alertPrefix string) (*IPHandler, error) {
+	ranger, err := rangerFromFile(IPListFilename)
+	if err != nil {
+		return nil, err
+	}
+	ih := MakeIPHandler(ranger, databaseChan, forwardHandler, alertPrefix)
+	ih.IPListFilename = IPListFilename
+	return ih, nil
+}
+
+// Reload triggers a reload of the contents of the file with the name.
+func (a *IPHandler) Reload() error {
+	ranger, err := rangerFromFile(a.IPListFilename)
+	if err != nil {
+		return err
+	}
+	a.Lock()
+	a.Ranger = ranger
+	a.Unlock()
+	return nil
+}
+
+// Consume processes an Entry, emitting alerts if there is a match
+func (a *IPHandler) Consume(e *types.Entry) error {
+	a.Lock()
+	srcRanges, err := a.Ranger.ContainingNetworks(net.ParseIP(e.SrcIP))
+	if err != nil {
+		log.Warn(err)
+	}
+	for _, v := range srcRanges {
+		n := MakeIPAlertEntryForHit(*e, e.SrcIP, v, a.AlertPrefix)
+		a.DatabaseEventChan <- n
+		a.ForwardHandler.Consume(&n)
+	}
+	dstRanges, err := a.Ranger.ContainingNetworks(net.ParseIP(e.DestIP))
+	if err != nil {
+		log.Warn(err)
+	}
+	for _, v := range dstRanges {
+		n := MakeIPAlertEntryForHit(*e, e.DestIP, v, a.AlertPrefix)
+		a.DatabaseEventChan <- n
+		a.ForwardHandler.Consume(&n)
+	}
+	a.Unlock()
+	return nil
+}
+
+// GetName returns the name of the handler
+func (a *IPHandler) GetName() string {
+	return "IP blacklist handler"
+}
+
+// GetEventTypes returns a slice of event type strings that this handler
+// should be applied to
+func (a *IPHandler) GetEventTypes() []string {
+	return []string{"http", "dns", "tls", "smtp", "flow", "ssh", "tls", "smb"}
+}

--- a/processing/ip_handler.go
+++ b/processing/ip_handler.go
@@ -141,7 +141,7 @@ func MakeIPHandlerFromFile(IPListFilename string,
 	return ih, nil
 }
 
-// Reload triggers a reload of the contents of the file with the name.
+// Reload triggers a reload of the contents of the IP list file.
 func (a *IPHandler) Reload() error {
 	ranger, err := rangerFromFile(a.IPListFilename)
 	if err != nil {

--- a/processing/ip_handler_test.go
+++ b/processing/ip_handler_test.go
@@ -1,0 +1,242 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2018, DCSO GmbH
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/yl2chen/cidranger"
+)
+
+var (
+	reIPmsg = regexp.MustCompile(`Communication involving IP ([^ ]+) in listed range ([^ ]+)`)
+)
+
+func makeIPHTTPEvent(srcip string, dstip string) types.Entry {
+	e := types.Entry{
+		SrcIP:      srcip,
+		SrcPort:    int64(rand.Intn(60000) + 1025),
+		DestIP:     dstip,
+		DestPort:   80,
+		Timestamp:  time.Now().Format(types.SuricataTimestampFormat),
+		EventType:  "http",
+		Proto:      "TCP",
+		HTTPHost:   "http://foo.bar",
+		HTTPUrl:    "/baz",
+		HTTPMethod: "GET",
+	}
+	eve := types.EveEvent{
+		EventType: e.EventType,
+		SrcIP:     e.SrcIP,
+		SrcPort:   int(e.SrcPort),
+		DestIP:    e.DestIP,
+		DestPort:  int(e.DestPort),
+		Proto:     e.Proto,
+		HTTP: &types.HTTPEvent{
+			Hostname: e.HTTPHost,
+			URL:      e.HTTPUrl,
+		},
+	}
+	json, err := json.Marshal(eve)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		e.JSONLine = string(json)
+	}
+	return e
+}
+
+var ipTestURLs []string
+var ipTestHosts []string
+
+// IPCollectorHandler gathers consumed alerts in a list
+type IPCollectorHandler struct {
+	Entries []string
+}
+
+func (h *IPCollectorHandler) GetName() string {
+	return "Collector handler"
+}
+
+func (h *IPCollectorHandler) GetEventTypes() []string {
+	return []string{"alert"}
+}
+
+func (h *IPCollectorHandler) Consume(e *types.Entry) error {
+	log.Info(e.JSONLine)
+	match := reIPmsg.FindStringSubmatch(e.JSONLine)
+	if match != nil {
+		h.Entries = append(h.Entries, e.JSONLine)
+		return nil
+	}
+	return nil
+}
+
+func TestIPHandler(t *testing.T) {
+	// make sure that alerts are forwarded
+	util.PrepareEventFilter([]string{"alert"}, false)
+
+	// channel to receive events to be saved to database
+	dbChan := make(chan types.Entry)
+
+	// handler to receive forwarded events
+	fwhandler := &IPCollectorHandler{
+		Entries: make([]string, 0),
+	}
+
+	// concurrently gather entries to be written to DB
+	dbWritten := make([]types.Entry, 0)
+	consumeWaitChan := make(chan bool)
+	go func() {
+		for e := range dbChan {
+			dbWritten = append(dbWritten, e)
+		}
+		close(consumeWaitChan)
+	}()
+
+	// make test ranger
+	_, network, _ := net.ParseCIDR("10.0.0.1/32")
+	rng := cidranger.NewPCTrieRanger()
+	rng.Insert(cidranger.NewBasicRangerEntry(*network))
+
+	ih := MakeIPHandler(rng, dbChan, fwhandler, "IPF")
+
+	bhTypes := ih.GetEventTypes()
+	if len(bhTypes) != 8 {
+		t.Fatal("IP handler should claim eight types")
+	}
+	if ih.GetName() != "IP blacklist handler" {
+		t.Fatal("IP handler has wrong name")
+	}
+
+	e := makeIPHTTPEvent("10.0.0.1", "10.0.0.2")
+	ih.Consume(&e)
+	e = makeIPHTTPEvent("10.0.0.3", "10.0.0.2")
+	ih.Consume(&e)
+	e = makeIPHTTPEvent("10.0.0.3", "10.0.0.1")
+	ih.Consume(&e)
+
+	// wait until all values have been collected
+	close(dbChan)
+	<-consumeWaitChan
+
+	// check that we haven't missed anything
+	if len(fwhandler.Entries) < 2 {
+		t.Fatalf("expected %d forwarded BLF alerts, seen less (%d)", 2,
+			len(fwhandler.Entries))
+	}
+}
+
+func TestIPHandlerFromFile(t *testing.T) {
+	// make sure that alerts are forwarded
+	util.PrepareEventFilter([]string{"alert"}, false)
+
+	// channel to receive events to be saved to database
+	dbChan := make(chan types.Entry)
+
+	// handler to receive forwarded events
+	fwhandler := &IPCollectorHandler{
+		Entries: make([]string, 0),
+	}
+
+	// concurrently gather entries to be written to DB
+	dbWritten := make([]types.Entry, 0)
+	consumeWaitChan := make(chan bool)
+	go func() {
+		for e := range dbChan {
+			dbWritten = append(dbWritten, e)
+		}
+		close(consumeWaitChan)
+	}()
+
+	ipFile, err := ioutil.TempFile("", "ipexample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(ipFile.Name())
+	w := bufio.NewWriter(ipFile)
+	_, err = w.WriteString("10.0.0.1/32\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+	ipFile.Close()
+
+	ih, err := MakeIPHandlerFromFile(ipFile.Name(), dbChan, fwhandler, "IPF")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bhTypes := ih.GetEventTypes()
+	if len(bhTypes) != 8 {
+		t.Fatal("IP handler should claim eight types")
+	}
+	if ih.GetName() != "IP blacklist handler" {
+		t.Fatal("IP handler has wrong name")
+	}
+
+	e := makeIPHTTPEvent("10.0.0.1", "10.0.0.2")
+	ih.Consume(&e)
+	e = makeIPHTTPEvent("10.0.0.3", "10.0.0.2")
+	ih.Consume(&e)
+	e = makeIPHTTPEvent("10.0.0.3", "10.0.0.1")
+	ih.Consume(&e)
+
+	// wait until all values have been collected
+	close(dbChan)
+	<-consumeWaitChan
+
+	// check that we haven't missed anything
+	if len(fwhandler.Entries) < 2 {
+		t.Fatalf("expected %d forwarded BLF alerts, seen less (%d)", 2,
+			len(fwhandler.Entries))
+	}
+
+}
+
+func TestIPHandlerFromFileInvalidFormat(t *testing.T) {
+	// channel to receive events to be saved to database
+	dbChan := make(chan types.Entry)
+
+	// handler to receive forwarded events
+	fwhandler := &IPCollectorHandler{
+		Entries: make([]string, 0),
+	}
+
+	ipFile, err := ioutil.TempFile("", "invalidipexample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(ipFile.Name())
+	w := bufio.NewWriter(ipFile)
+	_, err = w.WriteString("10.0.0.1/3q5435\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+	ipFile.Close()
+
+	hook := test.NewGlobal()
+	_, err = MakeIPHandlerFromFile(ipFile.Name(), dbChan, fwhandler, "IPF")
+
+	if len(hook.Entries) < 2 {
+		t.Fatal("missing log entries")
+	}
+	if hook.Entries[0].Message != "invalid IP range 10.0.0.1/3q5435, skipping" {
+		t.Fatal("wrong log entry for invalid IP range")
+	}
+}


### PR DESCRIPTION
This PR adds a new processing handler that, not unlike the Bloom fiter handler, emits alerts when source or destination IPs in any incoming event are within a list of CIDR ranges previously given to FEVER.

For instance, one could provide a list such as
```
10.0.0.0/24
35.190.247.0/24
```
which would cause any traffic from or to, say, 10.0.0.45 or 35.190.247.122 to generate an alert. The original contents of the EVE metadata item that caused the alert is attached inside the alert EVE, as it is done with traditional alerts generated by Suricata.

Here's what an alert would look like:
```json
{
  "timestamp": "2018-12-12T15:45:02.503513+0100",
  "event_type": "alert",
  "src_ip": "10.0.0.45",
  "src_port": 29636,
  "dest_ip": "10.1.2.3",
  "dest_port": 80,
  "proto": "TCP",
  "alert": {
    "action": "allowed",
    "gid": 0,
    "rev": 0,
    "signature": "IP BLACKLIST Communication involving IP 10.0.0.45 in listed range 10.0.0.0/24",
    "category": "Potentially Bad Traffic",
    "severity": 3
  },
  "http": {
    "hostname": "foo.bar",
    "url":"\/",
    "http_user_agent":"curl\/7.52.1",
    "http_content_type":"text\/html",
    "http_method":"GET",
    "protocol":"HTTP\/1.1",
    "status":200,
    "length":894
  }
}
```

Ranges to alert on are held in a trie implemented by cidranger (https://github.com/yl2chen/cidranger) so lookups are fast enough to be done on both IPs in potentially high-volume input data selections.