### PR TITLE
fix race condition in test

### DIFF
--- a/processing/ip_handler_test.go
+++ b/processing/ip_handler_test.go
@@ -236,10 +236,11 @@ func TestIPHandlerFromFileInvalidFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(hook.Entries) < 2 {
+	entries := hook.AllEntries()
+	if len(entries) < 2 {
 		t.Fatal("missing log entries")
 	}
-	if hook.Entries[0].Message != "invalid IP range 10.0.0.1/3q5435, skipping" {
+	if entries[0].Message != "invalid IP range 10.0.0.1/3q5435, skipping" {
 		t.Fatal("wrong log entry for invalid IP range")
 	}
 }

--- a/processing/ip_handler_test.go
+++ b/processing/ip_handler_test.go
@@ -232,6 +232,9 @@ func TestIPHandlerFromFileInvalidFormat(t *testing.T) {
 
 	hook := test.NewGlobal()
 	_, err = MakeIPHandlerFromFile(ipFile.Name(), dbChan, fwhandler, "IPF")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(hook.Entries) < 2 {
 		t.Fatal("missing log entries")


### PR DESCRIPTION
Access to global logrus hooks is only synchronized when using the `hook.AllEntries()` method. Failing to use these and accessing the `Entries` map directly will lead to races during concurrent log operations.