### PR TITLE
allow to disable forwarding

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -172,19 +172,25 @@ func mainfunc(cmd *cobra.Command, args []string) {
 	}
 	s.Run(eventChan)
 
+	var forwardHandler processing.Handler
 	reconnectTimes := viper.GetInt("reconnect-retries")
 	// start forwarding
-	forwardHandler := processing.MakeForwardHandler(int(reconnectTimes), outputSocket)
-	dispatcher.RegisterHandler(forwardHandler)
-	if pse != nil {
-		forwardHandler.SubmitStats(pse)
+	if forward {
+		forwardHandler = processing.MakeForwardHandler(int(reconnectTimes), outputSocket)
+		if pse != nil {
+			forwardHandler.(*processing.ForwardHandler).SubmitStats(pse)
+		}
+		forwardHandler.(*processing.ForwardHandler).Run()
+		defer func() {
+			c := make(chan bool)
+			forwardHandler.(*processing.ForwardHandler).Stop(c)
+			<-c
+		}()
+	} else {
+		// in this case we use a void handler that does nothing
+		forwardHandler = processing.MakeVoidHandler()
 	}
-	forwardHandler.Run()
-	defer func() {
-		c := make(chan bool)
-		forwardHandler.Stop(c)
-		<-c
-	}()
+	dispatcher.RegisterHandler(forwardHandler)
 
 	// Bloom filter setup
 	bloomFilePath := viper.GetString("bloom.file")

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -470,7 +470,7 @@ func init() {
 	viper.BindPFlag("input.redis.nopipe", runCmd.PersistentFlags().Lookup("in-redis-nopipe"))
 
 	// Output options
-	runCmd.PersistentFlags().StringP("out-socket", "o", "/tmp/suri-forward.sock", "path to output socket (to forwarder)")
+	runCmd.PersistentFlags().StringP("out-socket", "o", "/tmp/suri-forward.sock", "path to output socket (to forwarder), empty string disables forwarding")
 	viper.BindPFlag("output.socket", runCmd.PersistentFlags().Lookup("out-socket"))
 
 	// Forwarding options

--- a/processing/void_handler.go
+++ b/processing/void_handler.go
@@ -1,0 +1,46 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2019, DCSO GmbH
+
+import (
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// VoidHandler is a handler that does nothing.
+type VoidHandler struct {
+	Logger *log.Entry
+}
+
+// MakeVoidHandler creates a new forwarding handler
+func MakeVoidHandler() *VoidHandler {
+	fh := &VoidHandler{
+		Logger: log.WithFields(log.Fields{
+			"domain": "forward",
+		}),
+	}
+	return fh
+}
+
+// Consume processes an Entry and discards it
+func (fh *VoidHandler) Consume(e *types.Entry) error {
+	_ = e
+	return nil
+}
+
+// GetName returns the name of the handler
+func (fh *VoidHandler) GetName() string {
+	return "Void forwarding handler"
+}
+
+// GetEventTypes returns a slice of event type strings that this handler
+// should be applied to
+func (fh *VoidHandler) GetEventTypes() []string {
+	if util.ForwardAllEvents {
+		return []string{"*"}
+	}
+	return util.GetAllowedTypes()
+}


### PR DESCRIPTION
This PR introduces a means to disable forwarding by passing the empty string (`''`) to the `-o` option. This is done by adding a void forwarder in this case which simply does not act when receiving an item.

Closes #22.