### PR TITLE
include TLS metadata in SNI BLF alert

### DIFF
--- a/processing/bloom_handler.go
+++ b/processing/bloom_handler.go
@@ -68,6 +68,7 @@ func MakeAlertEntryForHit(e types.Entry, eType string, alertPrefix string) types
 			PacketInfo: eve.PacketInfo,
 			HTTP:       eve.HTTP,
 			DNS:        eve.DNS,
+			TLS:        eve.TLS,
 		}
 	}
 	newEntry := e


### PR DESCRIPTION
This PR makes sure that TLS metadata is added to an alert created by a Bloom filter hit on a TLS SNI value.