### PR TITLE
Make sure all events are written to database

### DIFF
--- a/db/slurper_postgres.go
+++ b/db/slurper_postgres.go
@@ -186,7 +186,7 @@ func (s *PostgresSlurper) slurpPostgres(eventchan chan types.Entry) {
 				s.Logger.WithFields(log.Fields{
 					"chunksize": s.ChunkSize,
 					"table":     s.CurrentTableName,
-				}).Info("COPY complete")
+				}).Debug("COPY complete")
 			}
 			copybuf.Reset()
 		}

--- a/processing/flow_aggregator_test.go
+++ b/processing/flow_aggregator_test.go
@@ -27,6 +27,8 @@ func makeFlowEvent() types.Entry {
 		PktsToClient:  int64(rand.Intn(100)),
 		PktsToServer:  int64(rand.Intn(100)),
 	}
+	jsonBytes, _ := json.Marshal(e)
+	e.JSONLine = string(jsonBytes)
 	return e
 }
 

--- a/processing/handler_dispatcher_test.go
+++ b/processing/handler_dispatcher_test.go
@@ -19,48 +19,6 @@ import (
 	"github.com/NeowayLabs/wabbit/amqptest/server"
 )
 
-func TestHandlerDispatcherDefaultHandler(t *testing.T) {
-	outChan := make(chan types.Entry)
-	closeChan := make(chan bool)
-	ad := MakeHandlerDispatcher(outChan)
-	vals := make([]string, 0)
-
-	defaultTypes := ad.DefaultHandler.GetEventTypes()
-	if len(defaultTypes) != 1 {
-		t.Fatal("default handler should only have one type")
-	}
-	if defaultTypes[0] != "not applicable" {
-		t.Fatal("default handler should only have one type, 'not applicable'")
-	}
-	if ad.DefaultHandler.GetName() != "Default handler" {
-		t.Fatal("default handler has wrong name")
-	}
-
-	go func(closeChan chan bool, inChan chan types.Entry) {
-		for v := range inChan {
-			vals = append(vals, v.JSONLine)
-		}
-		close(closeChan)
-	}(closeChan, outChan)
-
-	ad.Dispatch(&types.Entry{
-		JSONLine: "foo",
-	})
-	ad.Dispatch(&types.Entry{
-		JSONLine: "bar",
-	})
-
-	close(outChan)
-	<-closeChan
-
-	if len(vals) != 2 {
-		t.Fatal("wrong number of entries delivered to default handler")
-	}
-	if vals[0] != "foo" || vals[1] != "bar" {
-		t.Fatalf("wrong entries delivered to default handler: %s/%s", vals[0], vals[1])
-	}
-}
-
 type Test1Handler struct {
 	Vals []string
 }


### PR DESCRIPTION
This PR ensures that all events are written to the database if FEVER is configured to write to one. Previously only event types that were not subscribed to by any handler were written to the database as 'additional storage' as we would have forwarded the subscribed ones off the sensor to a central location via the forwarding mechanism anyway. 
We now dispatch all events to the database slurpers independently of subscription; this includes alerts generated by downstream handlers, e.g. Bloom filter or IP blacklist hits.

Closes #23.