### PR TITLE
fix test synchronization

### DIFF
--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -226,7 +226,6 @@ func (fh *ForwardHandler) Stop(stoppedChan chan bool) {
 		fh.OutputConn.Close()
 		fh.Lock.Unlock()
 		close(fh.StopReconnectChan)
-		close(fh.ReconnectNotifyChan)
 		close(fh.StopChan)
 		close(fh.ForwardEventChan)
 		fh.Running = false

--- a/processing/handler_dispatcher_test.go
+++ b/processing/handler_dispatcher_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/DCSO/fever/types"
 	"github.com/DCSO/fever/util"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/NeowayLabs/wabbit"
 	"github.com/NeowayLabs/wabbit/amqptest"
@@ -132,7 +131,6 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 	results := make([]string, 0)
 	c, err := util.NewConsumer(serverURL, "nsm.test.metrics", "direct", "nsm.test.metrics.testqueue",
 		"", "", func(d wabbit.Delivery) {
-			log.Info(string(d.Body()))
 			results = append(results, string(d.Body()))
 		})
 	if err != nil {


### PR DESCRIPTION
This MR improves stability of the Go test suite when exposed to slow test hosts by removing time-dependent test conditions. It also improves test robustness and runtime in general.