### PR TITLE
Allow for URL variation in Bloom filter indicators

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var verbose = false
 var dispatcher *processing.HandlerDispatcher
 var forward bool
 

--- a/input/input_redis.go
+++ b/input/input_redis.go
@@ -15,7 +15,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var cnt, lastcnt uint64
 var perfStatsSendInterval = 10 * time.Second
 var backOffTime = 500 * time.Millisecond
 

--- a/processing/bloom_handler_test.go
+++ b/processing/bloom_handler_test.go
@@ -449,3 +449,67 @@ func TestBloomHandlerEmptyInput(t *testing.T) {
 		t.Fatal("bloom filter should not be nil for empty file")
 	}
 }
+
+func TestBloomHandlerURL(t *testing.T) {
+	e1 := types.Entry{
+		SrcIP:      "10.0.0.1",
+		SrcPort:    23545,
+		DestIP:     "10.0.0.2",
+		DestPort:   80,
+		Timestamp:  time.Now().Format(types.SuricataTimestampFormat),
+		EventType:  "http",
+		Proto:      "TCP",
+		HTTPHost:   "foo.bar.de",
+		HTTPUrl:    "/",
+		HTTPMethod: "GET",
+	}
+	eve1 := types.EveEvent{
+		EventType: e1.EventType,
+		SrcIP:     e1.SrcIP,
+		SrcPort:   int(e1.SrcPort),
+		DestIP:    e1.DestIP,
+		DestPort:  int(e1.DestPort),
+		Proto:     e1.Proto,
+		HTTP: &types.HTTPEvent{
+			Hostname: e1.HTTPHost,
+			URL:      e1.HTTPUrl,
+		},
+	}
+	json1, err := json.Marshal(eve1)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		e1.JSONLine = string(json1)
+	}
+	e2 := types.Entry{
+		SrcIP:      "10.0.0.1",
+		SrcPort:    23545,
+		DestIP:     "10.0.0.2",
+		DestPort:   80,
+		Timestamp:  time.Now().Format(types.SuricataTimestampFormat),
+		EventType:  "http",
+		Proto:      "TCP",
+		HTTPHost:   "foo.bar.de",
+		HTTPUrl:    "/",
+		HTTPMethod: "GET",
+	}
+	eve2 := types.EveEvent{
+		EventType: e2.EventType,
+		SrcIP:     e2.SrcIP,
+		SrcPort:   int(e2.SrcPort),
+		DestIP:    e2.DestIP,
+		DestPort:  int(e2.DestPort),
+		Proto:     e2.Proto,
+		HTTP: &types.HTTPEvent{
+			Hostname: e2.HTTPHost,
+			URL:      e2.HTTPUrl,
+		},
+	}
+	json2, err := json.Marshal(eve2)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		e2.JSONLine = string(json2)
+	}
+
+}

--- a/processing/bloom_handler_test.go
+++ b/processing/bloom_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -174,7 +175,8 @@ func fillBloom(b *bloom.BloomFilter) {
 
 // CollectorHandler simply gathers consumed events in a list
 type CollectorHandler struct {
-	Entries map[string]bool
+	EntriesLock sync.Mutex
+	Entries     map[string]bool
 }
 
 func (h *CollectorHandler) GetName() string {
@@ -186,6 +188,8 @@ func (h *CollectorHandler) GetEventTypes() []string {
 }
 
 func (h *CollectorHandler) Consume(e *types.Entry) error {
+	h.EntriesLock.Lock()
+	defer h.EntriesLock.Unlock()
 	match := reHTTPURL.FindStringSubmatch(e.JSONLine)
 	if match != nil {
 		url := match[2]
@@ -209,6 +213,18 @@ func (h *CollectorHandler) Consume(e *types.Entry) error {
 		return nil
 	}
 	return nil
+}
+
+func (h *CollectorHandler) Reset() {
+	h.EntriesLock.Lock()
+	defer h.EntriesLock.Unlock()
+	h.Entries = make(map[string]bool)
+}
+
+func (h *CollectorHandler) GetEntries() map[string]bool {
+	h.EntriesLock.Lock()
+	defer h.EntriesLock.Unlock()
+	return h.Entries
 }
 
 func TestBloomHandler(t *testing.T) {
@@ -460,7 +476,7 @@ func TestBloomHandlerURL(t *testing.T) {
 		EventType:  "http",
 		Proto:      "TCP",
 		HTTPHost:   "foo.bar.de",
-		HTTPUrl:    "/",
+		HTTPUrl:    "http://foo.bar.de/oddlyspecific",
 		HTTPMethod: "GET",
 	}
 	eve1 := types.EveEvent{
@@ -490,7 +506,7 @@ func TestBloomHandlerURL(t *testing.T) {
 		EventType:  "http",
 		Proto:      "TCP",
 		HTTPHost:   "foo.bar.de",
-		HTTPUrl:    "/",
+		HTTPUrl:    "/oddlyspecific",
 		HTTPMethod: "GET",
 	}
 	eve2 := types.EveEvent{
@@ -510,6 +526,217 @@ func TestBloomHandlerURL(t *testing.T) {
 		log.Warn(err)
 	} else {
 		e2.JSONLine = string(json2)
+	}
+	e3 := types.Entry{
+		SrcIP:      "10.0.0.1",
+		SrcPort:    23545,
+		DestIP:     "10.0.0.2",
+		DestPort:   80,
+		Timestamp:  time.Now().Format(types.SuricataTimestampFormat),
+		EventType:  "http",
+		Proto:      "TCP",
+		HTTPHost:   "foo.bar.com",
+		HTTPUrl:    "/oddlyspecific",
+		HTTPMethod: "GET",
+	}
+	eve3 := types.EveEvent{
+		EventType: e3.EventType,
+		SrcIP:     e3.SrcIP,
+		SrcPort:   int(e3.SrcPort),
+		DestIP:    e3.DestIP,
+		DestPort:  int(e3.DestPort),
+		Proto:     e3.Proto,
+		HTTP: &types.HTTPEvent{
+			Hostname: e3.HTTPHost,
+			URL:      e3.HTTPUrl,
+		},
+	}
+	json3, err := json.Marshal(eve3)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		e3.JSONLine = string(json3)
+	}
+
+	dbChan := make(chan types.Entry)
+	dbWritten := make([]types.Entry, 0)
+	consumeWaitChan := make(chan bool)
+	go func() {
+		for e := range dbChan {
+			dbWritten = append(dbWritten, e)
+		}
+		close(consumeWaitChan)
+	}()
+
+	util.PrepareEventFilter([]string{"alert"}, false)
+
+	// initalize Bloom filter and fill with 'interesting' values
+	bf := bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("/oddlyspecific"))
+
+	// handler to receive forwarded events
+	fwhandler := &CollectorHandler{
+		Entries: make(map[string]bool),
+	}
+
+	bh := MakeBloomHandler(&bf, dbChan, fwhandler, "FOO BAR")
+	bh.Consume(&e1)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e1)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("http://foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e1)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("https://foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e1)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("https://foo.bar.com/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e1)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("/"))
+	fwhandler.Reset()
+	bh.Consume(&e1)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e2)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e2)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("http://foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e2)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("https://foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e2)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("https://foo.bar.com/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e2)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("/"))
+	fwhandler.Reset()
+	bh.Consume(&e2)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e3)
+
+	if len(fwhandler.GetEntries()) != 1 {
+		t.Fatalf("not enough alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e3)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("http://foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e3)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("https://foo.bar.de/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e3)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("https://foo.bar.com/oddlyspecific"))
+	fwhandler.Reset()
+	bh.Consume(&e3)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
+	}
+
+	bf = bloom.Initialize(100000, 0.0000001)
+	bf.Add([]byte("/"))
+	fwhandler.Reset()
+	bh.Consume(&e3)
+
+	if len(fwhandler.GetEntries()) != 0 {
+		t.Fatalf("too many alerts: %d", len(fwhandler.GetEntries()))
 	}
 
 }

--- a/processing/ip_handler_test.go
+++ b/processing/ip_handler_test.go
@@ -60,9 +60,6 @@ func makeIPHTTPEvent(srcip string, dstip string) types.Entry {
 	return e
 }
 
-var ipTestURLs []string
-var ipTestHosts []string
-
 // IPCollectorHandler gathers consumed alerts in a list
 type IPCollectorHandler struct {
 	Entries []string

--- a/types/eve.go
+++ b/types/eve.go
@@ -227,6 +227,11 @@ type packetInfo struct {
 	Linktype int `json:"linktype"`
 }
 
+// ExtraInfo contains non-EVE-standard extra information
+type ExtraInfo struct {
+	BloomIOC string `json:"bloom-ioc,omitempty"`
+}
+
 // EveEvent is the huge struct which can contain a parsed suricata eve.json
 // log event.
 type EveEvent struct {
@@ -257,4 +262,5 @@ type EveEvent struct {
 	SSH              *sshEvent      `json:"ssh,omitempty"`
 	TLS              *TLSEvent      `json:"tls,omitempty"`
 	Stats            *statsEvent    `json:"stats,omitempty"`
+	ExtraInfo        *ExtraInfo     `json:"_extra,omitempty"`
 }

--- a/types/flow_event.go
+++ b/types/flow_event.go
@@ -38,7 +38,7 @@ var maxBytes = int64(^uint32(0))
 func parseIP(stringIP string) ([]byte, error) {
 	ip := net.ParseIP(stringIP)
 	if ip == nil {
-		return nil, errors.New("Invalid IP")
+		return nil, errors.New("invalid IP")
 	}
 	ipv4 := ip.To4()
 	if ipv4 == nil {
@@ -99,7 +99,7 @@ func (fe *FlowEvent) FromEntry(e *Entry) error {
 	fe.Format |= 1 << 2 //bits 3,4,5 and 6 mark the version (currently 1)
 
 	if len(srcIP) != len(destIP) {
-		return fmt.Errorf("Source and destination IPS have different lengths O.o")
+		return fmt.Errorf("source and destination IPS have different lengths O.o")
 	}
 
 	if e.BytesToServer > maxBytes {

--- a/util/consumer.go
+++ b/util/consumer.go
@@ -60,13 +60,13 @@ func NewConsumer(amqpURI, exchange, exchangeType, queueName, key, ctag string, c
 	log.Debugf("dialing %q", amqpURI)
 	c.conn, err = amqptest.Dial(amqpURI)
 	if err != nil {
-		return nil, fmt.Errorf("Dial: %s", err)
+		return nil, fmt.Errorf("dial: %s", err)
 	}
 
 	log.Debugf("got Connection, getting Channel")
 	c.channel, err = c.conn.Channel()
 	if err != nil {
-		return nil, fmt.Errorf("Channel: %s", err)
+		return nil, fmt.Errorf("channel: %s", err)
 	}
 
 	log.Debugf("got Channel, declaring Exchange (%q)", exchange)
@@ -80,7 +80,7 @@ func NewConsumer(amqpURI, exchange, exchangeType, queueName, key, ctag string, c
 			"noWait":   false,
 		},
 	); err != nil {
-		return nil, fmt.Errorf("Exchange Declare: %s", err)
+		return nil, fmt.Errorf("exchange declare: %s", err)
 	}
 
 	queue, err := c.channel.QueueDeclare(
@@ -93,7 +93,7 @@ func NewConsumer(amqpURI, exchange, exchangeType, queueName, key, ctag string, c
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Queue Declare: %s", err)
+		return nil, fmt.Errorf("queue declare: %s", err)
 	}
 
 	log.Debugf("declared Queue (%q %d messages, %d consumers), binding to Exchange (key %q)",
@@ -107,7 +107,7 @@ func NewConsumer(amqpURI, exchange, exchangeType, queueName, key, ctag string, c
 			"noWait": false,
 		},
 	); err != nil {
-		return nil, fmt.Errorf("Queue Bind: %s", err)
+		return nil, fmt.Errorf("queue bind: %s", err)
 	}
 
 	log.Debugf("Queue bound to Exchange, starting Consume (consumer tag %q)", c.tag)
@@ -121,7 +121,7 @@ func NewConsumer(amqpURI, exchange, exchangeType, queueName, key, ctag string, c
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Queue Consume: %s", err)
+		return nil, fmt.Errorf("queue consume: %s", err)
 	}
 	go handle(deliveries, c.done, c.Callback)
 
@@ -132,7 +132,7 @@ func NewConsumer(amqpURI, exchange, exchangeType, queueName, key, ctag string, c
 func (c *Consumer) Shutdown() error {
 	// will close() the deliveries channel
 	if err := c.channel.Close(); err != nil {
-		return fmt.Errorf("Channel close failed: %s", err)
+		return fmt.Errorf("channel close failed: %s", err)
 	}
 	if err := c.conn.Close(); err != nil {
 		return fmt.Errorf("AMQP connection close error: %s", err)


### PR DESCRIPTION
Depending on annotation stringency, indicators in upstream threat intel sources may contain URL information in various different ways:
- with hostname, protocol and request path: `http://foo.bar.de/baz`
- with hostname and request path: `foo.bar.de/baz`
-  only request path, independent of host: `/baz`

This MR enumerates, for a given canonicalized URL observed in the EVE input, several variations of these and tries to match all of them against the global Bloom filter.

To allow for easier confirmation of these alerts against a full IoC database in postprocessing, we also add a `_extra.bloom-ioc` field in the alert EVE.