### PR TITLE
implement active reverse DNS enrichment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017, 2018, DCSO Deutsche Cyber-Sicherheitsorganisation GmbH
+Copyright (c) 2017, 2018, 2019, DCSO Deutsche Cyber-Sicherheitsorganisation GmbH
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Usage:
   fever run [flags]
 
 Flags:
+      --active-rdns                              enable active rDNS enrichment for src/dst IPs
+      --active-rdns-cache-expiry duration        cache expiry interval for rDNS lookups (default 2m0s)
+      --active-rdns-private-only                 only do active rDNS enrichment for RFC1918 IPs
+      --bloom-alert-prefix string                String prefix for Bloom filter alerts (default "BLF")
   -b, --bloom-file string                        Bloom filter for external indicator screening
   -z, --bloom-zipped                             use gzipped Bloom filter file
   -c, --chunksize uint                           chunk size for batched event handling (e.g. inserts) (default 50000)
@@ -42,11 +46,11 @@ Flags:
       --flowextract-bloom-selector string        IP address Bloom filter to select flows to extract
       --flowextract-enable                       extract and forward flow metadata
       --flowextract-submission-exchange string   Exchange to which raw flow events will be submitted (default "flows")
-      --flowextract-submission-url string        URL to which raw flow events will be submitted
+      --flowextract-submission-url string        URL to which raw flow events will be submitted (default "amqp://guest:guest@localhost:5672/")
   -n, --flowreport-interval duration             time interval for report submissions
       --flowreport-nocompress                    send uncompressed flow reports (default is gzip)
       --flowreport-submission-exchange string    Exchange to which flow reports will be submitted (default "aggregations")
-      --flowreport-submission-url string         URL to which flow reports will be submitted
+      --flowreport-submission-url string         URL to which flow reports will be submitted (default "amqp://guest:guest@localhost:5672/")
       --flushcount uint                          maximum number of events in one batch (e.g. for flow extraction) (default 100000)
   -f, --flushtime duration                       time interval for event aggregation (default 1m0s)
   -T, --fwd-all-types                            forward all event types
@@ -55,17 +59,20 @@ Flags:
   -r, --in-redis string                          Redis input server (assumes "suricata" list key, no pwd)
       --in-redis-nopipe                          do not use Redis pipelining
   -i, --in-socket string                         filename of input socket (accepts EVE JSON) (default "/tmp/suri.sock")
+      --ip-alert-prefix string                   String prefix for IP blacklist alerts (default "IP-BLACKLIST")
+      --ip-blacklist string                      List with IP ranges to alert on
       --logfile string                           Path to log file
       --logjson                                  Output logs in JSON format
       --metrics-enable                           submit performance metrics to central sink
       --metrics-submission-exchange string       Exchange to which metrics will be submitted (default "metrics")
-      --metrics-submission-url string            URL to which metrics will be submitted
-  -o, --out-socket string                        path to output socket (to forwarder) (default "/tmp/suri-forward.sock")
+      --metrics-submission-url string            URL to which metrics will be submitted (default "amqp://guest:guest@localhost:5672/")
+  -o, --out-socket string                        path to output socket (to forwarder), empty string disables forwarding (default "/tmp/suri-forward.sock")
       --pdns-enable                              collect and forward aggregated passive DNS data
       --pdns-submission-exchange string          Exchange to which passive DNS events will be submitted (default "pdns")
-      --pdns-submission-url string               URL to which passive DNS events will be submitted
+      --pdns-submission-url string               URL to which passive DNS events will be submitted (default "amqp://guest:guest@localhost:5672/")
       --profile string                           enable runtime profiling to given file
       --reconnect-retries uint                   number of retries connecting to socket or sink, 0 = no retry limit
+      --toolname string                          set toolname (default "fever")
   -v, --verbose                                  enable verbose logging (debug log level)
 
 Global Flags:

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -179,6 +179,10 @@ func mainfunc(cmd *cobra.Command, args []string) {
 		if pse != nil {
 			forwardHandler.(*processing.ForwardHandler).SubmitStats(pse)
 		}
+		rdns := viper.GetBool("active.rdns")
+		if rdns {
+			forwardHandler.(*processing.ForwardHandler).EnableRDNS()
+		}
 		forwardHandler.(*processing.ForwardHandler).Run()
 		defer func() {
 			c := make(chan bool)
@@ -563,6 +567,10 @@ func init() {
 	viper.BindPFlag("flowextract.submission-url", runCmd.PersistentFlags().Lookup("flowextract-submission-url"))
 	runCmd.PersistentFlags().StringP("flowextract-submission-exchange", "", "flows", "Exchange to which raw flow events will be submitted")
 	viper.BindPFlag("flowextract.submission-exchange", runCmd.PersistentFlags().Lookup("flowextract-submission-exchange"))
+
+	// Active enrichment options
+	runCmd.PersistentFlags().BoolP("active-rdns", "", false, "enable active rDNS enrichment for src/dst IPs")
+	viper.BindPFlag("active.rdns", runCmd.PersistentFlags().Lookup("active-rdns"))
 
 	// Logging options
 	runCmd.PersistentFlags().StringP("logfile", "", "", "Path to log file")

--- a/fever.yaml
+++ b/fever.yaml
@@ -92,6 +92,11 @@ flowextract:
 #  zipped: true
 #  alert-prefix: BLF
 
+# Configuration for active information gathering.
+active:
+  # Enable reverse DNS lookups for src/dst IPs.
+  rdns: false
+
 logging:
   # Insert file name here to redirect logs to separate file.
   file: 

--- a/fever.yaml
+++ b/fever.yaml
@@ -96,6 +96,8 @@ flowextract:
 active:
   # Enable reverse DNS lookups for src/dst IPs.
   rdns: false
+  rdns-private-only: true
+  rdns-cache-expiry: 120s
 
 logging:
   # Insert file name here to redirect logs to separate file.

--- a/processing/rdns_handler.go
+++ b/processing/rdns_handler.go
@@ -1,0 +1,63 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2019, DCSO GmbH
+
+import (
+	"sync"
+
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// RDNSHandler is a handler that enriches events with reverse DNS
+// information looked up on the sensor, for both source and destination
+// IP addresses.
+type RDNSHandler struct {
+	sync.Mutex
+	Logger    *log.Entry
+	HostNamer *util.HostNamer
+}
+
+// MakeRDNSHandler returns a new RDNSHandler, backed by the passed HostNamer.
+func MakeRDNSHandler(hn *util.HostNamer) *RDNSHandler {
+	rh := &RDNSHandler{
+		Logger: log.WithFields(log.Fields{
+			"domain": "rdns",
+		}),
+		HostNamer: hn,
+	}
+	return rh
+}
+
+// Consume processes an Entry and enriches it
+func (a *RDNSHandler) Consume(e *types.Entry) error {
+	var err error
+	var res []string
+	if e.SrcIP != "" {
+		res, err = a.HostNamer.GetHostname(e.SrcIP)
+		if err == nil {
+			e.SrcHosts = res
+		}
+	}
+	if e.DestIP != "" {
+		res, err = a.HostNamer.GetHostname(e.DestIP)
+		if err == nil {
+			e.DestHosts = res
+		}
+	}
+	return nil
+}
+
+// GetName returns the name of the handler
+func (a *RDNSHandler) GetName() string {
+	return "reverse DNS handler"
+}
+
+// GetEventTypes returns a slice of event type strings that this handler
+// should be applied to
+func (a *RDNSHandler) GetEventTypes() []string {
+	return []string{"http", "dns", "tls", "smtp", "flow", "ssh", "tls", "smb", "alert"}
+}

--- a/processing/rdns_handler.go
+++ b/processing/rdns_handler.go
@@ -38,8 +38,12 @@ func MakeRDNSHandler(hn *util.HostNamer) *RDNSHandler {
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
+		"fc00::/7",
 	} {
-		_, block, _ := net.ParseCIDR(cidr)
+		_, block, err := net.ParseCIDR(cidr)
+		if err != nil {
+			log.Fatalf("cannot parse fixed private IP range %v", cidr)
+		}
 		rh.PrivateRanges.Insert(cidranger.NewBasicRangerEntry(*block))
 	}
 	return rh

--- a/types/entry.go
+++ b/types/entry.go
@@ -15,8 +15,10 @@ type DNSAnswer struct {
 // Entry is a collection of data that needs to be parsed FAST from the entry
 type Entry struct {
 	SrcIP         string
+	SrcHosts      []string
 	SrcPort       int64
 	DestIP        string
+	DestHosts     []string
 	DestPort      int64
 	Timestamp     string
 	EventType     string

--- a/types/eve.go
+++ b/types/eve.go
@@ -241,8 +241,10 @@ type EveEvent struct {
 	InIface          string         `json:"in_iface,omitempty"`
 	SrcIP            string         `json:"src_ip,omitempty"`
 	SrcPort          int            `json:"src_port,omitempty"`
+	SrcHost          []string       `json:"src_host,omitempty"`
 	DestIP           string         `json:"dest_ip,omitempty"`
 	DestPort         int            `json:"dest_port,omitempty"`
+	DestHost         []string       `json:"dest_host,omitempty"`
 	Proto            string         `json:"proto,omitempty"`
 	AppProto         string         `json:"app_proto,omitempty"`
 	TxID             int            `json:"tx_id,omitempty"`

--- a/util/hostnamer.go
+++ b/util/hostnamer.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// HostNamer is a component that provides cached hostnames for IP
+// addresses passed as strings.
+type HostNamer struct {
+	Cache *cache.Cache
+	Lock  sync.Mutex
+}
+
+// NewHostNamer returns a new HostNamer with the given default expiration time.
+// Data entries will be purged after each cleanupInterval.
+func NewHostNamer(defaultExpiration, cleanupInterval time.Duration) *HostNamer {
+	return &HostNamer{
+		Cache: cache.New(defaultExpiration, cleanupInterval),
+	}
+}
+
+// GetHostname returns a list of host names for a given IP address.
+func (n *HostNamer) GetHostname(ipAddr string) ([]string, error) {
+	n.Lock.Lock()
+	defer n.Lock.Unlock()
+
+	val, found := n.Cache.Get(ipAddr)
+	if found {
+		return val.([]string), nil
+	}
+	hns, err := net.LookupAddr(ipAddr)
+	if err != nil {
+		return nil, err
+	}
+	for i, hn := range hns {
+		hns[i] = strings.TrimRight(hn, ".")
+	}
+	n.Cache.Set(ipAddr, hns, cache.DefaultExpiration)
+	val = hns
+	return val.([]string), nil
+}
+
+// Flush clears the cache of a HostNamer.
+func (n *HostNamer) Flush() {
+	n.Cache.Flush()
+}

--- a/util/hostnamer_test.go
+++ b/util/hostnamer_test.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHostNamerQuad8(t *testing.T) {
+	hn := NewHostNamer(5*time.Second, 5*time.Second)
+	v, err := hn.GetHostname("8.8.8.8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v) == 0 {
+		t.Fatal("no response")
+	}
+	v, err = hn.GetHostname("8.8.8.8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v) == 0 {
+		t.Fatal("no response")
+	}
+	time.Sleep(6 * time.Second)
+	v, err = hn.GetHostname("8.8.8.8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v) == 0 {
+		t.Fatal("no response")
+	}
+}
+
+func TestHostNamerInvalid(t *testing.T) {
+	hn := NewHostNamer(5*time.Second, 5*time.Second)
+	_, err := hn.GetHostname("8.")
+	if err == nil {
+		t.Fatal("missed error")
+	}
+}

--- a/util/hostnamer_test.go
+++ b/util/hostnamer_test.go
@@ -3,32 +3,48 @@ package util
 import (
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func TestHostNamerQuad8(t *testing.T) {
+func _TestHostNamerQuad8(t *testing.T, ip string) {
 	hn := NewHostNamer(5*time.Second, 5*time.Second)
-	v, err := hn.GetHostname("8.8.8.8")
+	v, err := hn.GetHostname(ip)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(v) == 0 {
 		t.Fatal("no response")
+	} else {
+		log.Debugf("got response %v", v)
 	}
-	v, err = hn.GetHostname("8.8.8.8")
+	v, err = hn.GetHostname(ip)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(v) == 0 {
 		t.Fatal("no response")
+	} else {
+		log.Debugf("got response %v", v)
 	}
 	time.Sleep(6 * time.Second)
-	v, err = hn.GetHostname("8.8.8.8")
+	v, err = hn.GetHostname(ip)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(v) == 0 {
 		t.Fatal("no response")
+	} else {
+		log.Debugf("got response %v", v)
 	}
+}
+
+func TestHostNamerQuad8v4(t *testing.T) {
+	_TestHostNamerQuad8(t, "8.8.8.8")
+}
+
+func TestHostNamerQuad8v6(t *testing.T) {
+	_TestHostNamerQuad8(t, "2001:4860:4860::8888")
 }
 
 func TestHostNamerInvalid(t *testing.T) {


### PR DESCRIPTION
This PR introduces a new processing handler to add hostnames to source and destination IPs observed in input events, as looked up by active reverse DNS queries. This enrichment is performed at time of alert forwarding and is also implemented hooking into the forwarder, as we might also want to annotate alerts that have been created by FEVER itself, e.g. from BLF hits.

Query results are cached to limit overall queries in the management network, with configurable cache expiry time (`--active-rdns-cache-expiry`). Optionally one can limit the annotations/lookups to RFC1918 private IPs only (`--active.rdns-private-only`). 

By default this active feature is switched off, and by default both public and private IPs are annotated.