### PR TITLE
allow AMQP channel multiplexing

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -83,12 +83,12 @@ func mainfunc(cmd *cobra.Command, args []string) {
 			metricsSubmissionExchange := viper.GetString("metrics.submission-exchange")
 			statssubmitter, err = util.MakeAMQPSubmitterWithReconnector(metricsSubmissionURL,
 				metricsSubmissionExchange,
-				verbose, func(amqpURI string) (wabbit.Conn, string, error) {
+				verbose, func(amqpURI string) (wabbit.Conn, error) {
 					conn, err := amqp.Dial(amqpURI)
 					if err != nil {
-						return nil, "topic", err
+						return nil, err
 					}
-					return conn, "topic", err
+					return conn, err
 				})
 			if err != nil {
 				log.Fatal(err)

--- a/processing/flow_extractor_test.go
+++ b/processing/flow_extractor_test.go
@@ -88,10 +88,10 @@ func TestFlowExtractor(t *testing.T) {
 
 	// set up submitter
 	submitter, err := util.MakeAMQPSubmitterWithReconnector(serverURL,
-		"tdh.flows", true, func(url string) (wabbit.Conn, string, error) {
+		"tdh.flows", true, func(url string) (wabbit.Conn, error) {
 			var conn wabbit.Conn
 			conn, err = amqptest.Dial(url)
-			return conn, "direct", err
+			return conn, err
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/processing/handler_dispatcher_test.go
+++ b/processing/handler_dispatcher_test.go
@@ -139,11 +139,11 @@ func TestHandlerDispatcherMonitoring(t *testing.T) {
 
 	// set up submitter
 	statssubmitter, err := util.MakeAMQPSubmitterWithReconnector(serverURL,
-		"nsm.test.metrics", true, func(url string) (wabbit.Conn, string, error) {
+		"nsm.test.metrics", true, func(url string) (wabbit.Conn, error) {
 			// we pass in a custom reconnector which uses the amqptest implementation
 			var conn wabbit.Conn
 			conn, err = amqptest.Dial(url)
-			return conn, "direct", err
+			return conn, err
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/util/performance_stats_encoder_test.go
+++ b/util/performance_stats_encoder_test.go
@@ -57,11 +57,11 @@ func TestPerformanceStatsEncoderEmpty(t *testing.T) {
 
 	// set up submitter
 	statssubmitter, err := MakeAMQPSubmitterWithReconnector(serverURL,
-		"tdh.metrics", true, func(url string) (wabbit.Conn, string, error) {
+		"tdh.metrics", true, func(url string) (wabbit.Conn, error) {
 			// we pass in a custom reconnector which uses the amqptest implementation
 			var conn wabbit.Conn
 			conn, err = amqptest.Dial(url)
-			return conn, "direct", err
+			return conn, err
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -105,11 +105,11 @@ func TestPerformanceStatsEncoder(t *testing.T) {
 
 	// set up submitter
 	statssubmitter, err := MakeAMQPSubmitterWithReconnector(serverURL,
-		"tdh.metrics", true, func(url string) (wabbit.Conn, string, error) {
+		"tdh.metrics", true, func(url string) (wabbit.Conn, error) {
 			// we pass in a custom reconnector which uses the amqptest implementation
 			var conn wabbit.Conn
 			conn, err = amqptest.Dial(url)
-			return conn, "direct", err
+			return conn, err
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/util/submitter_amqp.go
+++ b/util/submitter_amqp.go
@@ -143,7 +143,7 @@ func MakeAMQPSubmitterWithReconnector(url string, target string, verbose bool,
 
 		gSubmitters[url] = mySubmitter
 		mySubmitter.NofSubmitters++
-		mySubmitter.Logger.Debugf("number of submitters now %v", mySubmitter.NofSubmitters)
+		mySubmitter.Logger.Debugf("number of submitters now %d", mySubmitter.NofSubmitters)
 	} else {
 		mySubmitter = gSubmitters[url]
 	}
@@ -236,6 +236,6 @@ func (s *AMQPSubmitter) Finish() {
 		delete(gSubmitters, s.Submitter.URL)
 	} else {
 		s.Submitter.NofSubmitters--
-		s.Submitter.Logger.Debugf("number of submitters now %v", s.Submitter.NofSubmitters)
+		s.Submitter.Logger.Debugf("number of submitters now %d", s.Submitter.NofSubmitters)
 	}
 }

--- a/util/submitter_test.go
+++ b/util/submitter_test.go
@@ -19,8 +19,8 @@ import (
 func TestInvalidReconnector(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	submitter, err := MakeAMQPSubmitterWithReconnector("amqp://sensor:sensor@localhost:9999/%2f",
-		"foo.bar.test", true, func(url string) (wabbit.Conn, string, error) {
-			return nil, "", fmt.Errorf("error")
+		"foo.bar.test", true, func(url string) (wabbit.Conn, error) {
+			return nil, fmt.Errorf("error")
 		})
 	if submitter != nil || err == nil {
 		t.Fail()
@@ -51,11 +51,11 @@ func TestSubmitter(t *testing.T) {
 
 	// set up submitter
 	submitter, err := MakeAMQPSubmitterWithReconnector(serverURL,
-		"foo.bar.test", true, func(url string) (wabbit.Conn, string, error) {
+		"foo.bar.test", true, func(url string) (wabbit.Conn, error) {
 			// we pass in a custom reconnector which uses the amqptest implementation
 			var conn wabbit.Conn
 			conn, err = amqptest.Dial(url)
-			return conn, "direct", err
+			return conn, err
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -106,11 +106,11 @@ func TestSubmitterReconnect(t *testing.T) {
 
 	// set up submitter
 	submitter, err := MakeAMQPSubmitterWithReconnector(serverURL,
-		"foo.bar.test", true, func(url string) (wabbit.Conn, string, error) {
+		"foo.bar.test", true, func(url string) (wabbit.Conn, error) {
 			// we pass in a custom reconnector which uses the amqptest implementation
 			var conn wabbit.Conn
 			conn, err = amqptest.Dial(url)
-			return conn, "direct", err
+			return conn, err
 		})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR introduces a new feature:

- No longer create a new connection and channel for each desired exchange submitter, but reuse existing channels if they exist. This should help decrease the number of connections on the RabbitMQ server side.

Also fixes a bug that can cause infinite loops in goroutines after AMQP reconnects.