### PR TITLE
add metadata context submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Flags:
   -b, --bloom-file string                        Bloom filter for external indicator screening
   -z, --bloom-zipped                             use gzipped Bloom filter file
   -c, --chunksize uint                           chunk size for batched event handling (e.g. inserts) (default 50000)
+      --context-enable                           collect and forward flow context for alerted flows
+      --context-submission-exchange string       Exchange to which flow context events will be submitted (default "context")
+      --context-submission-url string            URL to which flow context will be submitted (default "amqp://guest:guest@localhost:5672/")
   -d, --db-database string                       database DB (default "events")
       --db-enable                                write events to database
   -s, --db-host string                           database host (default "localhost:5432")

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Flags:
       --active-rdns-cache-expiry duration        cache expiry interval for rDNS lookups (default 2m0s)
       --active-rdns-private-only                 only do active rDNS enrichment for RFC1918 IPs
       --bloom-alert-prefix string                String prefix for Bloom filter alerts (default "BLF")
+      --bloom-blacklist-iocs strings             Blacklisted strings in Bloom filter (will cause filter to be rejected) (default [/,/index.htm,/index.html])
   -b, --bloom-file string                        Bloom filter for external indicator screening
   -z, --bloom-zipped                             use gzipped Bloom filter file
   -c, --chunksize uint                           chunk size for batched event handling (e.g. inserts) (default 50000)

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -280,11 +280,13 @@ func mainfunc(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+
 		processing.GlobalContextCollector = processing.MakeContextCollector(
 			func(entries processing.Context, logger *log.Entry) error {
 				shipChan <- entries
 				return nil
 			},
+			viper.GetDuration("context.cache-timeout"),
 		)
 		dispatcher.RegisterHandler(processing.GlobalContextCollector)
 		if pse != nil {
@@ -601,6 +603,8 @@ func init() {
 	viper.BindPFlag("context.submission-url", runCmd.PersistentFlags().Lookup("context-submission-url"))
 	runCmd.PersistentFlags().StringP("context-submission-exchange", "", "context", "Exchange to which flow context events will be submitted")
 	viper.BindPFlag("context.submission-exchange", runCmd.PersistentFlags().Lookup("context-submission-exchange"))
+	runCmd.PersistentFlags().DurationP("context-cache-timeout", "", 60*time.Minute, "time for flow metadata to be kept for uncompleted flows")
+	viper.BindPFlag("context.cache-timeout", runCmd.PersistentFlags().Lookup("context-cache-timeout"))
 
 	// Bloom filter alerting options
 	runCmd.PersistentFlags().StringP("bloom-file", "b", "", "Bloom filter for external indicator screening")

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -255,6 +255,49 @@ func mainfunc(cmd *cobra.Command, args []string) {
 		<-c
 	}()
 
+	// context collector setup
+	enableContext := viper.GetBool("context.enable")
+	if enableContext {
+		var csubmitter util.StatsSubmitter
+		if dummyMode {
+			csubmitter, err = util.MakeDummySubmitter()
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			cSubmissionURL := viper.GetString("context.submission-url")
+			cSubmissionExchange := viper.GetString("context.submission-exchange")
+			csubmitter, err = util.MakeAMQPSubmitter(cSubmissionURL,
+				cSubmissionExchange, verbose)
+			if err != nil {
+				log.Fatal(err)
+			}
+			csubmitter.UseCompression()
+			defer csubmitter.Finish()
+		}
+		cshp := processing.ContextShipperAMQP{}
+		shipChan, err := cshp.Start(csubmitter)
+		if err != nil {
+			log.Fatal(err)
+		}
+		processing.GlobalContextCollector = processing.MakeContextCollector(
+			func(entries processing.Context, logger *log.Entry) error {
+				shipChan <- entries
+				return nil
+			},
+		)
+		dispatcher.RegisterHandler(processing.GlobalContextCollector)
+		if pse != nil {
+			processing.GlobalContextCollector.SubmitStats(pse)
+		}
+		processing.GlobalContextCollector.Run()
+		defer func() {
+			c := make(chan bool)
+			processing.GlobalContextCollector.Stop(c)
+			<-c
+		}()
+	}
+
 	// passive DNS setup
 	enablePDNS := viper.GetBool("pdns.enable")
 	if enablePDNS {
@@ -383,7 +426,6 @@ func mainfunc(cmd *cobra.Command, args []string) {
 
 		dispatcher.RegisterHandler(ua)
 		ua.Run()
-
 		defer func() {
 			c := make(chan bool)
 			ua.Stop(c)
@@ -551,6 +593,14 @@ func init() {
 	viper.BindPFlag("pdns.submission-url", runCmd.PersistentFlags().Lookup("pdns-submission-url"))
 	runCmd.PersistentFlags().StringP("pdns-submission-exchange", "", "pdns", "Exchange to which passive DNS events will be submitted")
 	viper.BindPFlag("pdns.submission-exchange", runCmd.PersistentFlags().Lookup("pdns-submission-exchange"))
+
+	// Context collection options
+	runCmd.PersistentFlags().BoolP("context-enable", "", false, "collect and forward flow context for alerted flows")
+	viper.BindPFlag("context.enable", runCmd.PersistentFlags().Lookup("context-enable"))
+	runCmd.PersistentFlags().StringP("context-submission-url", "", "amqp://guest:guest@localhost:5672/", "URL to which flow context will be submitted")
+	viper.BindPFlag("context.submission-url", runCmd.PersistentFlags().Lookup("context-submission-url"))
+	runCmd.PersistentFlags().StringP("context-submission-exchange", "", "context", "Exchange to which flow context events will be submitted")
+	viper.BindPFlag("context.submission-exchange", runCmd.PersistentFlags().Lookup("context-submission-exchange"))
 
 	// Bloom filter alerting options
 	runCmd.PersistentFlags().StringP("bloom-file", "b", "", "Bloom filter for external indicator screening")

--- a/fever.yaml
+++ b/fever.yaml
@@ -76,6 +76,12 @@ pdns:
   submission-url: amqp://guest:guest@localhost:5672/
   submission-exchange: pdns
 
+# Configuration for alert-associated metadata submission.
+context:
+  enable: false
+  submission-url: amqp://guest:guest@localhost:5672/
+  submission-exchange: context
+
 # Configuration for detailed flow metadata submission.
 flowextract:
   enable: false

--- a/fever.yaml
+++ b/fever.yaml
@@ -79,6 +79,7 @@ pdns:
 # Configuration for alert-associated metadata submission.
 context:
   enable: false
+  cache-timeout: 1h
   submission-url: amqp://guest:guest@localhost:5672/
   submission-exchange: context
 

--- a/processing/bloom_handler.go
+++ b/processing/bloom_handler.go
@@ -58,6 +58,7 @@ func MakeAlertEntryForHit(e types.Entry, eType string, alertPrefix string, ioc s
 				Category:  "Potentially Bad Traffic",
 				Signature: fmt.Sprintf(sig, alertPrefix) + value,
 			},
+			FlowID:     eve.FlowID,
 			Stream:     eve.Stream,
 			InIface:    eve.InIface,
 			SrcIP:      eve.SrcIP,

--- a/processing/context_collector.go
+++ b/processing/context_collector.go
@@ -1,0 +1,198 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2019, DCSO GmbH
+
+import (
+	"sync"
+	"time"
+
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+
+	"github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// ContextCollectorDefaultTTL is the default time after which a Context
+	// in the cache will be expired.
+	ContextCollectorDefaultTTL = 5 * time.Minute
+)
+
+// GlobalContextCollector is a shared ContextCollector to be used by FEVER.
+var GlobalContextCollector *ContextCollector
+
+// ContextShipper is a function that processes a slice of Entries that make up a
+// context of an alert, e.g. all events that share a flow ID relevant for the
+// alert.
+type ContextShipper func(Context, *log.Entry) error
+
+// ContextCollectorPerfStats contains performance stats written to InfluxDB
+// for monitoring.
+type ContextCollectorPerfStats struct {
+	Flows     uint64 `influx:"context_flows"`
+	Events    uint64 `influx:"context_events"`
+	JSONBytes uint64 `influx:"context_json_bytes"`
+}
+
+// ContextCollector is a component that maintains a cache of metadata per
+// flow ID, forwarding it to a specified sink if associated with an alert.
+type ContextCollector struct {
+	PerfStats          ContextCollectorPerfStats
+	StatsEncoder       *util.PerformanceStatsEncoder
+	StopChan           chan bool
+	StoppedChan        chan bool
+	StopCounterChan    chan bool
+	StoppedCounterChan chan bool
+	Running            bool
+	StatsLock          sync.Mutex
+
+	Cache    *cache.Cache
+	MarkLock sync.Mutex
+	Marked   map[string]struct{}
+	Logger   *log.Entry
+	i        uint64
+	Ship     ContextShipper
+}
+
+// Context is a collection of JSON events that belong to a given flow.
+type Context []string
+
+// MakeContextCollector creates a new ContextCollector.
+func MakeContextCollector(shipper ContextShipper) *ContextCollector {
+	c := &ContextCollector{
+		Logger: log.WithFields(log.Fields{
+			"domain": "context",
+		}),
+		Cache:  cache.New(ContextCollectorDefaultTTL, ContextCollectorDefaultTTL),
+		Marked: make(map[string]struct{}),
+		i:      0,
+		Ship:   shipper,
+	}
+	return c
+}
+
+// Mark queues metadata for a given flow for forwarding, identified by its
+// flow ID.
+func (c *ContextCollector) Mark(flowID string) {
+	// when seeing an alert, just mark the flow ID as relevant
+	c.MarkLock.Lock()
+	c.Marked[flowID] = struct{}{}
+	c.MarkLock.Unlock()
+}
+
+// Consume processes an Entry, adding the data within to the internal
+// aggregated state
+func (c *ContextCollector) Consume(e *types.Entry) error {
+	var myC Context
+	// Some events, e.g. stats, have no flow ID set
+	if e.FlowID == "" {
+		return nil
+	}
+
+	cval, exist := c.Cache.Get(e.FlowID)
+	if exist {
+		// the 'flow' event always comes last, so we can use it as an
+		// indicator that the flow is complete and can be processed
+		if e.EventType == "flow" {
+			var isMarked bool
+			c.MarkLock.Lock()
+			if _, ok := c.Marked[e.FlowID]; ok {
+				isMarked = true
+			}
+			c.MarkLock.Unlock()
+			if isMarked {
+				c.StatsLock.Lock()
+				c.PerfStats.Flows++
+				c.PerfStats.Events += uint64(len(cval.(Context)))
+				for _, v := range cval.(Context) {
+					c.PerfStats.JSONBytes += uint64(len(v))
+				}
+				c.StatsLock.Unlock()
+				c.Ship(cval.(Context), c.Logger)
+				delete(c.Marked, e.FlowID)
+			}
+			c.Cache.Delete(e.FlowID)
+		} else {
+			myC = cval.(Context)
+			myC = append(myC, e.JSONLine)
+			c.Cache.Set(e.FlowID, myC, cache.DefaultExpiration)
+		}
+	} else {
+		if e.EventType != "flow" {
+			myC = append(myC, e.JSONLine)
+			c.Cache.Set(e.FlowID, myC, cache.DefaultExpiration)
+		}
+	}
+	c.i++
+	if c.i%100000 == 0 {
+		count := c.Cache.ItemCount()
+		c.Logger.WithFields(log.Fields{
+			"n": count,
+		}).Debugf("cache size after another 100k events")
+		c.i = 0
+	}
+	return nil
+}
+
+func (c *ContextCollector) runCounter() {
+	sTime := time.Now()
+	for {
+		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-c.StopCounterChan:
+			close(c.StoppedCounterChan)
+			return
+		default:
+			if c.StatsEncoder == nil || time.Since(sTime) < c.StatsEncoder.SubmitPeriod {
+				continue
+			}
+			c.StatsEncoder.Submit(c.PerfStats)
+			c.StatsLock.Lock()
+			c.PerfStats.JSONBytes = 0
+			c.PerfStats.Flows = 0
+			c.PerfStats.Events = 0
+			sTime = time.Now()
+			c.StatsLock.Unlock()
+		}
+	}
+}
+
+// GetName returns the name of the handler
+func (c *ContextCollector) GetName() string {
+	return "Context collector"
+}
+
+// GetEventTypes returns a slice of event type strings that this handler
+// should be applied to
+func (c *ContextCollector) GetEventTypes() []string {
+	return []string{"*"}
+}
+
+// Run starts the metrics collection and submission in the ContextCollector.
+func (c *ContextCollector) Run() {
+	if !c.Running {
+		c.StopChan = make(chan bool)
+		c.StopCounterChan = make(chan bool)
+		c.StoppedCounterChan = make(chan bool)
+		go c.runCounter()
+		c.Running = true
+	}
+}
+
+// Stop stops the metrics collection and submission in the ContextCollector.
+func (c *ContextCollector) Stop(stoppedChan chan bool) {
+	if c.Running {
+		close(c.StopCounterChan)
+		<-c.StoppedCounterChan
+		c.StoppedChan = stoppedChan
+		close(c.StopChan)
+		c.Running = false
+	}
+}
+
+// SubmitStats registers a PerformanceStatsEncoder for runtime stats submission.
+func (c *ContextCollector) SubmitStats(sc *util.PerformanceStatsEncoder) {
+	c.StatsEncoder = sc
+}

--- a/processing/context_collector.go
+++ b/processing/context_collector.go
@@ -14,12 +14,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// ContextCollectorDefaultTTL is the default time after which a Context
-	// in the cache will be expired.
-	ContextCollectorDefaultTTL = 5 * time.Minute
-)
-
 // GlobalContextCollector is a shared ContextCollector to be used by FEVER.
 var GlobalContextCollector *ContextCollector
 
@@ -60,16 +54,17 @@ type ContextCollector struct {
 type Context []string
 
 // MakeContextCollector creates a new ContextCollector.
-func MakeContextCollector(shipper ContextShipper) *ContextCollector {
+func MakeContextCollector(shipper ContextShipper, defaultTTL time.Duration) *ContextCollector {
 	c := &ContextCollector{
 		Logger: log.WithFields(log.Fields{
 			"domain": "context",
 		}),
-		Cache:  cache.New(ContextCollectorDefaultTTL, ContextCollectorDefaultTTL),
+		Cache:  cache.New(defaultTTL, defaultTTL),
 		Marked: make(map[string]struct{}),
 		i:      0,
 		Ship:   shipper,
 	}
+	c.Logger.Debugf("created cache with default TTL %v", defaultTTL)
 	return c
 }
 

--- a/processing/context_collector_test.go
+++ b/processing/context_collector_test.go
@@ -47,7 +47,7 @@ func TestContextCollector(t *testing.T) {
 		}
 		return nil
 	}
-	cc := MakeContextCollector(dsub)
+	cc := MakeContextCollector(dsub, 5*time.Minute)
 
 	nofReports := 0
 	for i := 0; i < 10000; i++ {
@@ -92,7 +92,7 @@ func TestContextCollectorMissingFlowID(t *testing.T) {
 		count++
 		return nil
 	}
-	cc := MakeContextCollector(dsub)
+	cc := MakeContextCollector(dsub, 5*time.Minute)
 
 	cc.Consume(&e)
 

--- a/processing/context_collector_test.go
+++ b/processing/context_collector_test.go
@@ -1,0 +1,113 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2019, DCSO GmbH
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/DCSO/fever/types"
+	log "github.com/sirupsen/logrus"
+)
+
+func makeCCTestEvent(eType, flowID string) types.Entry {
+	e := types.Entry{
+		SrcIP:     fmt.Sprintf("10.%d.%d.%d", rand.Intn(250), rand.Intn(250), rand.Intn(250)),
+		SrcPort:   []int64{1, 2, 3, 4, 5}[rand.Intn(5)],
+		DestIP:    fmt.Sprintf("10.0.0.%d", rand.Intn(250)),
+		DestPort:  []int64{11, 12, 13, 14, 15}[rand.Intn(5)],
+		Timestamp: time.Now().Format(types.SuricataTimestampFormat),
+		EventType: eType,
+		Proto:     "TCP",
+		FlowID:    flowID,
+	}
+	jsonBytes, _ := json.Marshal(e)
+	e.JSONLine = string(jsonBytes)
+	return e
+}
+
+func TestContextCollector(t *testing.T) {
+	markedVals := make(map[string][]string)
+	seenMarked := make(map[string][]string)
+	dsub := func(entries Context, logger *log.Entry) error {
+		for _, v := range entries {
+			var parsed struct {
+				FlowID string
+			}
+			err := json.Unmarshal([]byte(v), &parsed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			seenMarked[parsed.FlowID] = append(seenMarked[parsed.FlowID], v)
+		}
+		return nil
+	}
+	cc := MakeContextCollector(dsub)
+
+	nofReports := 0
+	for i := 0; i < 10000; i++ {
+		isMarked := (rand.Intn(20) < 1)
+		flowID := fmt.Sprintf("%d", rand.Intn(10000000)+10000)
+		if isMarked {
+			nofReports++
+			cc.Mark(flowID)
+		}
+		for j := 0; j < rand.Intn(200)+1; j++ {
+			ev := makeCCTestEvent([]string{"http", "smb", "dns"}[rand.Intn(3)], flowID)
+			if isMarked {
+				markedVals[flowID] = append(markedVals[flowID], ev.JSONLine)
+			}
+			cc.Consume(&ev)
+		}
+
+		ev := makeCCTestEvent("flow", flowID)
+		cc.Consume(&ev)
+	}
+
+	if len(markedVals) != len(seenMarked) {
+		t.Fatalf("number of marked flows (%d) != number of results (%d)", len(markedVals), len(seenMarked))
+	}
+
+	if !reflect.DeepEqual(markedVals, seenMarked) {
+		t.Fatal("contents of results and recorded metadata maps differ")
+	}
+}
+
+func TestContextCollectorMissingFlowID(t *testing.T) {
+	e := types.Entry{
+		Timestamp: time.Now().Format(types.SuricataTimestampFormat),
+		EventType: "stats",
+	}
+	jsonBytes, _ := json.Marshal(e)
+	e.JSONLine = string(jsonBytes)
+
+	count := 0
+
+	dsub := func(entries Context, logger *log.Entry) error {
+		count++
+		return nil
+	}
+	cc := MakeContextCollector(dsub)
+
+	cc.Consume(&e)
+
+	if count != 0 {
+		t.Fatalf("event with empty flow ID was considered")
+	}
+
+	flowID := "12345"
+	cc.Mark(flowID)
+	ev := makeCCTestEvent("dns", flowID)
+	cc.Consume(&ev)
+	ev = makeCCTestEvent("flow", flowID)
+	cc.Consume(&ev)
+
+	if count != 1 {
+		t.Fatalf("wrong number of entries: %d", count)
+	}
+}

--- a/processing/context_shipper_amqp.go
+++ b/processing/context_shipper_amqp.go
@@ -1,0 +1,75 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2019, DCSO GmbH
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/DCSO/fever/util"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// ContextQueueLength is the length of the queue buffering incoming context
+	// bundles to balance out potential transmission delays.
+	ContextQueueLength = 100
+)
+
+// ContextChunk represents a collection of events for transmission via AMQP.
+type ContextChunk struct {
+	Timestamp time.Time     `json:"timestamp"`
+	SensorID  string        `json:"sensor_id"`
+	Events    []interface{} `json:"events"`
+}
+
+// ContextShipperAMQP is a ContextShipper that sends incoming context bundles to
+// an AMQP exchange.
+type ContextShipperAMQP struct {
+	Submitter util.StatsSubmitter
+	InChan    chan Context
+	SensorID  string
+}
+
+// Start initiates the concurrent handling of incoming context bundles in the
+// Shipper's input channel. It will stop automatically once this channel is
+// closed.
+func (cs *ContextShipperAMQP) Start(s util.StatsSubmitter) (chan<- Context, error) {
+	var err error
+	cs.Submitter = s
+	cs.InChan = make(chan Context, ContextQueueLength)
+	cs.SensorID, err = util.GetSensorID()
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for ctx := range cs.InChan {
+			out := make([]interface{}, 0)
+			for _, ctxItem := range ctx {
+				var myItem interface{}
+				err := json.Unmarshal([]byte(ctxItem), &myItem)
+				if err != nil {
+					log.Warnf("Could not marshal event JSON: %s", string(ctxItem))
+					continue
+				}
+				out = append(out, myItem)
+			}
+			chunk := ContextChunk{
+				Timestamp: time.Now(),
+				SensorID:  cs.SensorID,
+				Events:    out,
+			}
+			json, err := json.Marshal(chunk)
+			if err != nil {
+				log.Warn(err)
+				continue
+			}
+			s.Submit(json, "context", "application/json")
+		}
+	}()
+
+	return cs.InChan, nil
+}

--- a/processing/context_shipper_amqp.go
+++ b/processing/context_shipper_amqp.go
@@ -52,7 +52,7 @@ func (cs *ContextShipperAMQP) Start(s util.StatsSubmitter) (chan<- Context, erro
 				var myItem interface{}
 				err := json.Unmarshal([]byte(ctxItem), &myItem)
 				if err != nil {
-					log.Warnf("Could not marshal event JSON: %s", string(ctxItem))
+					log.Warnf("could not marshal event JSON: %s", string(ctxItem))
 					continue
 				}
 				out = append(out, myItem)

--- a/processing/context_shipper_amqp_test.go
+++ b/processing/context_shipper_amqp_test.go
@@ -1,0 +1,119 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2019, DCSO GmbH
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DCSO/fever/util"
+
+	"github.com/NeowayLabs/wabbit"
+	"github.com/NeowayLabs/wabbit/amqptest"
+	"github.com/NeowayLabs/wabbit/amqptest/server"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestContextShipperAMQP(t *testing.T) {
+	serverURL := "amqp://sensor:sensor@localhost:9988/%2f/"
+	log.SetLevel(log.DebugLevel)
+
+	// start mock server
+	fakeServer := server.NewServer(serverURL)
+	fakeServer.Start()
+
+	// set up consumer
+	allDone := make(chan bool)
+	coll := make([]string, 0)
+	c, err := util.NewConsumer(serverURL, "context", "direct", "context",
+		"context", "foo-test1", func(d wabbit.Delivery) {
+			coll = append(coll, string(d.Body()))
+			if len(coll) == 4 {
+				allDone <- true
+			}
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// set up submitter
+	submitter, err := util.MakeAMQPSubmitterWithReconnector(serverURL,
+		"context", true, func(url string) (wabbit.Conn, error) {
+			// we pass in a custom reconnector which uses the amqptest implementation
+			var conn wabbit.Conn
+			conn, err = amqptest.Dial(url)
+			return conn, err
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := &ContextShipperAMQP{}
+	inChan, err := cs.Start(submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inChan <- Context{`{"value":"c1"}`}
+	inChan <- Context{`{"value":"c2"}`}
+	inChan <- Context{`{"value":"c3"}`}
+	inChan <- Context{`{"value":"c4"}`}
+
+	// ... and wait until they are received and processed
+	<-allDone
+	// check if output is correct
+	if len(coll) != 4 {
+		t.Fail()
+	}
+	if !strings.Contains(coll[0], `"value":"c1"`) {
+		t.Fatalf("value 1 incorrect: %v", coll[0])
+	}
+	if !strings.Contains(coll[1], `"value":"c2"`) {
+		t.Fatalf("value 2 incorrect: %v", coll[1])
+	}
+	if !strings.Contains(coll[2], `"value":"c3"`) {
+		t.Fatalf("value 3 incorrect: %v", coll[2])
+	}
+	if !strings.Contains(coll[3], `"value":"c4"`) {
+		t.Fatalf("value 4 incorrect: %v", coll[3])
+	}
+
+	close(inChan)
+
+	// tear down test setup
+	submitter.Finish()
+	fakeServer.Stop()
+	c.Shutdown()
+}
+
+func TestContextShipperAMQPBrokenJSON(t *testing.T) {
+	cs := &ContextShipperAMQP{}
+	ds, _ := util.MakeDummySubmitter()
+	inChan, err := cs.Start(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hook := test.NewGlobal()
+	var entries []*log.Entry
+
+	inChan <- Context{`{""value":1}`}
+
+	for i := 0; i < 60; i++ {
+		time.Sleep(1 * time.Second)
+		entries = hook.AllEntries()
+		if len(entries) > 0 {
+			break
+		}
+		if i > 58 {
+			t.Fatalf("timed out trying to receive error message for malformed JSON")
+		}
+	}
+
+	close(inChan)
+	if entries[0].Message != `Could not marshal event JSON: {""value":1}` {
+		t.Fatalf("wrong error message: %v", entries[0].Message)
+	}
+}

--- a/processing/context_shipper_amqp_test.go
+++ b/processing/context_shipper_amqp_test.go
@@ -113,7 +113,7 @@ func TestContextShipperAMQPBrokenJSON(t *testing.T) {
 	}
 
 	close(inChan)
-	if entries[0].Message != `Could not marshal event JSON: {""value":1}` {
+	if entries[0].Message != `could not marshal event JSON: {""value":1}` {
 		t.Fatalf("wrong error message: %v", entries[0].Message)
 	}
 }

--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -28,6 +28,7 @@ type ForwardHandler struct {
 	Logger              *log.Entry
 	DoRDNS              bool
 	RDNSHandler         *RDNSHandler
+	ContextCollector    *ContextCollector
 	ForwardEventChan    chan []byte
 	OutputSocket        string
 	OutputConn          net.Conn
@@ -184,6 +185,9 @@ func (fh *ForwardHandler) Consume(e *types.Entry) error {
 		err := json.Unmarshal([]byte(e.JSONLine), &ev)
 		if err != nil {
 			return err
+		}
+		if GlobalContextCollector != nil && e.EventType == "alert" {
+			GlobalContextCollector.Mark(string(e.FlowID))
 		}
 		if fh.DoRDNS && fh.RDNSHandler != nil {
 			err = fh.RDNSHandler.Consume(e)

--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -186,7 +186,7 @@ func (fh *ForwardHandler) Consume(e *types.Entry) error {
 		if err != nil {
 			return err
 		}
-		if GlobalContextCollector != nil && e.EventType == "alert" {
+		if GlobalContextCollector != nil && e.EventType == types.EventTypeAlert {
 			GlobalContextCollector.Mark(string(e.FlowID))
 		}
 		if fh.DoRDNS && fh.RDNSHandler != nil {

--- a/processing/pdns_collector.go
+++ b/processing/pdns_collector.go
@@ -1,7 +1,7 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2017, DCSO GmbH
+// Copyright (c) 2017, 2019, DCSO GmbH
 
 import (
 	"bytes"

--- a/types/entry.go
+++ b/types/entry.go
@@ -39,4 +39,5 @@ type Entry struct {
 	BytesToServer int64
 	PktsToClient  int64
 	PktsToServer  int64
+	FlowID        string
 }

--- a/types/eve.go
+++ b/types/eve.go
@@ -8,9 +8,16 @@ import (
 	"time"
 )
 
-// SuricataTimestampFormat is a Go time formatting string describing the
-// timestamp format used by Suricata's EVE JSON output.
-const SuricataTimestampFormat = "2006-01-02T15:04:05.999999-0700"
+const (
+	// SuricataTimestampFormat is a Go time formatting string describing the
+	// timestamp format used by Suricata's EVE JSON output.
+	SuricataTimestampFormat = "2006-01-02T15:04:05.999999-0700"
+
+	// EventTypeFlow is the EventType string for the flow type.
+	EventTypeFlow = "flow"
+	// EventTypeAlert is the EventType string for the alert type.
+	EventTypeAlert = "alert"
+)
 
 type suriTime struct{ time.Time }
 

--- a/util/util.go
+++ b/util/util.go
@@ -44,6 +44,7 @@ var evekeys = [][]string{
 	[]string{"tls", "sni"},             // 19
 	[]string{"dns", "version"},         // 20
 	[]string{"dns", "answers"},         // 21
+	[]string{"flow_id"},                // 22
 }
 
 // ParseJSON extracts relevant fields from an EVE JSON entry into an Entry struct.
@@ -212,9 +213,15 @@ func ParseJSON(json []byte) (e types.Entry, parseerr error) {
 				parseerr = err
 				return
 			}
+		case 22:
+			e.FlowID, err = jsonparser.ParseString(value)
+			if err != nil {
+				parseerr = err
+				return
+			}
 		}
 	}, evekeys...)
-	e.JSONLine = string(json[:])
+	e.JSONLine = string(json)
 
 	return e, parseerr
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -27,6 +27,7 @@ var entries = []types.Entry{
 		DNSRCode:  "NOERROR",
 		DNSRData:  "10.0.0.12",
 		DNSType:   "answer",
+		FlowID:    "4711",
 	},
 	types.Entry{
 		SrcIP:      "10.0.0.10",
@@ -40,6 +41,7 @@ var entries = []types.Entry{
 		HTTPHost:   "api.icndb.com",
 		HTTPUrl:    `/jokes/random?firstName=Chuck&lastName=Norris&limitTo=[nerdy]`,
 		HTTPMethod: `GET`,
+		FlowID:     "2323",
 	},
 	types.Entry{
 		SrcIP:      "10.0.0.10",
@@ -53,6 +55,7 @@ var entries = []types.Entry{
 		HTTPHost:   "foobar",
 		HTTPUrl:    `/scripts/wpnbr.dll`,
 		HTTPMethod: `POST`,
+		FlowID:     "2134",
 	},
 }
 


### PR DESCRIPTION
This PR adds support for sending collections of metadata events for flows that correspond to forwarded alerts to a specific AMQP endpoint. This is useful, for example, to support analysts with understanding the context of the alert.

We introduce a new config section:
```yaml
# Configuration for alert-associated metadata submission.
context:
  enable: false
  submission-url: amqp://guest:guest@localhost:5672/
  submission-exchange: context
```
and associated command line items:
```
--context-enable                           collect and forward flow context for alerted flows
--context-submission-exchange string       Exchange to which flow context events will be submitted (default "context")
--context-submission-url string            URL to which flow context will be submitted (default "amqp://guest:guest@localhost:5672/")
```
to configure this feature.

Data will be sent in compressed JSON items with the following structure:
```json
{
   "timestamp": "2019-08-23T14:24:50.094478126Z",
    "sensor_id": "f3b29d34da564f6997e03dac51472ab6",
    "events": [
           ...events...
       ]
}
```