### PR TITLE
Ensure flow ID transmission

### DIFF
--- a/processing/bloom_handler.go
+++ b/processing/bloom_handler.go
@@ -58,6 +58,7 @@ func MakeAlertEntryForHit(e types.Entry, eType string, alertPrefix string, ioc s
 				Category:  "Potentially Bad Traffic",
 				Signature: fmt.Sprintf(sig, alertPrefix) + value,
 			},
+			FlowID:     eve.FlowID,
 			Stream:     eve.Stream,
 			InIface:    eve.InIface,
 			SrcIP:      eve.SrcIP,

--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -1,7 +1,7 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2017, DCSO GmbH
+// Copyright (c) 2017, 2019, DCSO GmbH
 
 import (
 	"encoding/json"
@@ -180,7 +180,7 @@ func MakeForwardHandler(reconnectTimes int, outputSocket string) *ForwardHandler
 func (fh *ForwardHandler) Consume(e *types.Entry) error {
 	doForwardThis := util.ForwardAllEvents || util.AllowType(e.EventType)
 	if doForwardThis {
-		var ev types.EveEvent
+		var ev types.EveOutEvent
 		err := json.Unmarshal([]byte(e.JSONLine), &ev)
 		if err != nil {
 			return err

--- a/processing/forward_handler_test.go
+++ b/processing/forward_handler_test.go
@@ -155,7 +155,7 @@ func TestForwardHandler(t *testing.T) {
 		t.Fatalf("unexpected number of alerts: %d != 2", len(coll))
 	}
 
-	var eve types.EveEvent
+	var eve types.EveOutEvent
 	err = json.Unmarshal([]byte(coll[0]), &eve)
 	if err != nil {
 		t.Fatal(err)
@@ -235,7 +235,7 @@ func TestForwardAllHandler(t *testing.T) {
 	if len(coll) != 3 {
 		t.Fatalf("unexpected number of alerts: %d != 3", len(coll))
 	}
-	var eve types.EveEvent
+	var eve types.EveOutEvent
 	err = json.Unmarshal([]byte(coll[0]), &eve)
 	if err != nil {
 		t.Fatal(err)

--- a/types/eve.go
+++ b/types/eve.go
@@ -1,9 +1,11 @@
 package types
 
 // DCSO FEVER
-// Copyright (c) 2017, DCSO GmbH
+// Copyright (c) 2017, 2019, DCSO GmbH
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -269,4 +271,47 @@ type EveEvent struct {
 	TLS              *TLSEvent      `json:"tls,omitempty"`
 	Stats            *statsEvent    `json:"stats,omitempty"`
 	ExtraInfo        *ExtraInfo     `json:"_extra,omitempty"`
+}
+
+// EveOutEvent is the version of EveEvent that we use to marshal the output for
+// downstream consumption.
+type EveOutEvent EveEvent
+
+// MarshalJSON for EveOutEvents ensures that FlowIDs are represented in JSON
+// as a string. This is necessary to work around some arbitrary limitations such
+// as syslog-ng's funny JSON parser implementation, which truncates large
+// integers found in JSON values.
+func (e EveOutEvent) MarshalJSON() ([]byte, error) {
+	type Alias EveOutEvent
+	v, err := json.Marshal(&struct {
+		FlowID string `json:"flow_id"`
+		Alias
+	}{
+		FlowID: fmt.Sprintf("%d", e.FlowID),
+		Alias:  (Alias)(e),
+	})
+	return v, err
+}
+
+// UnmarshalJSON implements filling an EveOutEvent from a byte slice, converting
+// the string in the FlowID field back into a number. This is necessary to
+// ensure that a round-trip (write+read) works.
+func (e *EveOutEvent) UnmarshalJSON(d []byte) error {
+	type EveOutEvent2 EveOutEvent
+	x := struct {
+		EveOutEvent2
+		FlowID json.Number `json:"flow_id"`
+	}{EveOutEvent2: EveOutEvent2(*e)}
+
+	if err := json.Unmarshal(d, &x); err != nil {
+		return err
+	}
+	*e = EveOutEvent(x.EveOutEvent2)
+	var err error
+	if x.FlowID.String() == "" {
+		e.FlowID = 0
+		return nil
+	}
+	e.FlowID, err = strconv.ParseInt(x.FlowID.String(), 10, 64)
+	return err
 }

--- a/types/eve.go
+++ b/types/eve.go
@@ -5,7 +5,6 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"time"
 )
@@ -287,7 +286,7 @@ func (e EveOutEvent) MarshalJSON() ([]byte, error) {
 		FlowID string `json:"flow_id"`
 		Alias
 	}{
-		FlowID: fmt.Sprintf("%d", e.FlowID),
+		FlowID: strconv.FormatInt(e.FlowID, 10),
 		Alias:  (Alias)(e),
 	})
 	return v, err
@@ -308,10 +307,6 @@ func (e *EveOutEvent) UnmarshalJSON(d []byte) error {
 	}
 	*e = EveOutEvent(x.EveOutEvent2)
 	var err error
-	if x.FlowID.String() == "" {
-		e.FlowID = 0
-		return nil
-	}
-	e.FlowID, err = strconv.ParseInt(x.FlowID.String(), 10, 64)
+	e.FlowID, _ = x.FlowID.Int64() // ignore error; defaulting to zero
 	return err
 }


### PR DESCRIPTION
syslog-ng apparently has a bug (to be confirmed) that will silently convert JSON numbers larger than INT_MAX to strings containing INT_MAX in decimal. Obviously this issue causes the same wrong flow ID to be reported for all forwarded events. This MR introduces a workaround: flow IDs are converted to strings within  FEVER before being forwarded, so this problem does not occur.