### PR TITLE
Avoid marshaling EVE-JSON with fixed schema when modifying items

### DIFF
--- a/processing/bloom_handler.go
+++ b/processing/bloom_handler.go
@@ -1,10 +1,9 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2017, 2019, DCSO GmbH
+// Copyright (c) 2017, 2020, DCSO GmbH
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -13,17 +12,18 @@ import (
 
 	"github.com/DCSO/fever/types"
 	"github.com/DCSO/fever/util"
+	"github.com/buger/jsonparser"
 
 	"github.com/DCSO/bloom"
 	log "github.com/sirupsen/logrus"
 )
 
 var sigs = map[string]string{
-	"http-url":  "%s Possibly bad HTTP URL: ",
-	"http-host": "%s Possibly bad HTTP host: ",
-	"tls-sni":   "%s Possibly bad TLS SNI: ",
-	"dns-req":   "%s Possibly bad DNS lookup to ",
-	"dns-resp":  "%s Possibly bad DNS response for ",
+	"http-url":  "\"%s Possibly bad HTTP URL: %s\"",
+	"http-host": "\"%s Possibly bad HTTP host: %s\"",
+	"tls-sni":   "\"%s Possibly bad TLS SNI: %s\"",
+	"dns-req":   "\"%s Possibly bad DNS lookup to %s\"",
+	"dns-resp":  "\"%s Possibly bad DNS response for %s\"",
 }
 
 // MakeAlertEntryForHit returns an alert Entry as raised by an external
@@ -31,60 +31,53 @@ var sigs = map[string]string{
 // the triggering event's metadata (e.g. 'dns' or 'http' objects) as well as
 // its timestamp.
 func MakeAlertEntryForHit(e types.Entry, eType string, alertPrefix string, ioc string) types.Entry {
-	var eve types.EveEvent
-	var newEve types.EveEvent
-	var err = json.Unmarshal([]byte(e.JSONLine), &eve)
-	if err != nil {
-		log.Warn(err, e.JSONLine)
-	} else {
-		var value string
-		if eType == "http-url" {
-			value = fmt.Sprintf("%s | %s | %s", e.HTTPMethod, e.HTTPHost, e.HTTPUrl)
-		} else if eType == "http-host" {
-			value = e.HTTPHost
-		} else if strings.HasPrefix(eType, "dns") {
-			value = e.DNSRRName
-		} else if eType == "tls-sni" {
-			value = e.TLSSni
-		}
-		var sig = "%s Possibly bad traffic: "
-		if v, ok := sigs[eType]; ok {
-			sig = v
-		}
-		newEve = types.EveEvent{
-			EventType: "alert",
-			Alert: &types.AlertEvent{
-				Action:    "allowed",
-				Category:  "Potentially Bad Traffic",
-				Signature: fmt.Sprintf(sig, alertPrefix) + value,
-			},
-			FlowID:     eve.FlowID,
-			Stream:     eve.Stream,
-			InIface:    eve.InIface,
-			SrcIP:      eve.SrcIP,
-			SrcPort:    eve.SrcPort,
-			DestIP:     eve.DestIP,
-			DestPort:   eve.DestPort,
-			Proto:      eve.Proto,
-			TxID:       eve.TxID,
-			Timestamp:  eve.Timestamp,
-			PacketInfo: eve.PacketInfo,
-			HTTP:       eve.HTTP,
-			DNS:        eve.DNS,
-			TLS:        eve.TLS,
-			ExtraInfo: &types.ExtraInfo{
-				BloomIOC: ioc,
-			},
-		}
+
+	var value string
+	if eType == "http-url" {
+		value = fmt.Sprintf("%s | %s | %s", e.HTTPMethod, e.HTTPHost, e.HTTPUrl)
+	} else if eType == "http-host" {
+		value = e.HTTPHost
+	} else if strings.HasPrefix(eType, "dns") {
+		value = e.DNSRRName
+	} else if eType == "tls-sni" {
+		value = e.TLSSni
+	}
+	var sig = "\"%s Possibly bad traffic: %s\""
+	if v, ok := sigs[eType]; ok {
+		sig = v
 	}
 	newEntry := e
-	json, err := json.Marshal(newEve)
-	if err != nil {
-		log.Warn(err)
-	} else {
-		newEntry.JSONLine = string(json)
-	}
 	newEntry.EventType = "alert"
+	l, err := jsonparser.Set([]byte(newEntry.JSONLine), []byte("\"alert\""), "event_type")
+	if err != nil {
+		log.Warning(err)
+	} else {
+		newEntry.JSONLine = string(l)
+	}
+	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte("\"allowed\""), "alert", "action")
+	if err != nil {
+		log.Warning(err)
+	} else {
+		newEntry.JSONLine = string(l)
+	}
+	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte("\"Potentially Bad Traffic\""), "alert", "category")
+	if err != nil {
+		log.Warning(err)
+	} else {
+		newEntry.JSONLine = string(l)
+	}
+	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte(fmt.Sprintf("\"%s\"", ioc)), "_extra", "bloom-ioc")
+	if err != nil {
+		log.Warning(err)
+	} else {
+		newEntry.JSONLine = string(l)
+	}
+	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte(fmt.Sprintf(sig, alertPrefix, value)), "alert", "signature")
+	if err != nil {
+		log.Warning(err)
+	} else {
+		newEntry.JSONLine = string(l)
+	}
 
 	return newEntry
 }

--- a/processing/bloom_handler_test.go
+++ b/processing/bloom_handler_test.go
@@ -1,7 +1,7 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2017, 2018, 2019, DCSO GmbH
+// Copyright (c) 2017, 2020, DCSO GmbH
 
 import (
 	"encoding/json"
@@ -46,6 +46,9 @@ func makeBloomDNSEvent(rrname string) types.Entry {
 		DNSType:   []string{"answer", "query"}[rand.Intn(2)],
 	}
 	eve := types.EveEvent{
+		Timestamp: &types.SuriTime{
+			Time: time.Now(),
+		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
 		SrcPort:   int(e.SrcPort),
@@ -83,6 +86,9 @@ func makeBloomHTTPEvent(host string, url string) types.Entry {
 		HTTPMethod: "GET",
 	}
 	eve := types.EveEvent{
+		Timestamp: &types.SuriTime{
+			Time: time.Now(),
+		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
 		SrcPort:   int(e.SrcPort),
@@ -115,6 +121,9 @@ func makeBloomTLSEvent(host string) types.Entry {
 		TLSSni:    host,
 	}
 	eve := types.EveEvent{
+		Timestamp: &types.SuriTime{
+			Time: time.Now(),
+		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
 		SrcPort:   int(e.SrcPort),

--- a/processing/bloom_handler_test.go
+++ b/processing/bloom_handler_test.go
@@ -47,7 +47,7 @@ func makeBloomDNSEvent(rrname string) types.Entry {
 	}
 	eve := types.EveEvent{
 		Timestamp: &types.SuriTime{
-			Time: time.Now(),
+			Time: time.Now().UTC(),
 		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
@@ -87,7 +87,7 @@ func makeBloomHTTPEvent(host string, url string) types.Entry {
 	}
 	eve := types.EveEvent{
 		Timestamp: &types.SuriTime{
-			Time: time.Now(),
+			Time: time.Now().UTC(),
 		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
@@ -122,7 +122,7 @@ func makeBloomTLSEvent(host string) types.Entry {
 	}
 	eve := types.EveEvent{
 		Timestamp: &types.SuriTime{
-			Time: time.Now(),
+			Time: time.Now().UTC(),
 		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,

--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -227,7 +227,7 @@ func (fh *ForwardHandler) GetEventTypes() []string {
 // IPs in outgoing EVE events.
 func (fh *ForwardHandler) EnableRDNS(expiryPeriod time.Duration) {
 	fh.DoRDNS = true
-	fh.RDNSHandler = MakeRDNSHandler(util.NewHostNamer(expiryPeriod, 2*expiryPeriod))
+	fh.RDNSHandler = MakeRDNSHandler(util.NewHostNamerRDNS(expiryPeriod, 2*expiryPeriod))
 }
 
 // EnableStenosis ...

--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -1,11 +1,10 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2017, 2019, 2020, DCSO GmbH
+// Copyright (c) 2017, 2020, DCSO GmbH
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"net"
 	"sync"
 	"time"
@@ -185,34 +184,23 @@ func MakeForwardHandler(reconnectTimes int, outputSocket string) *ForwardHandler
 func (fh *ForwardHandler) Consume(e *types.Entry) error {
 	doForwardThis := util.ForwardAllEvents || util.AllowType(e.EventType)
 	if doForwardThis {
-		var ev types.EveOutEvent
-		err := json.Unmarshal([]byte(e.JSONLine), &ev)
-		if err != nil {
-			return err
-		}
 		// mark flow as relevant when alert is seen
 		if GlobalContextCollector != nil && e.EventType == types.EventTypeAlert {
 			GlobalContextCollector.Mark(string(e.FlowID))
 		}
 		// we also perform active rDNS enrichment if requested
 		if fh.DoRDNS && fh.RDNSHandler != nil {
-			err = fh.RDNSHandler.Consume(e)
+			err := fh.RDNSHandler.Consume(e)
 			if err != nil {
 				return err
 			}
-			ev.SrcHost = e.SrcHosts
-			ev.DestHost = e.DestHosts
 		}
 		// if we use Stenosis, the Stenosis connector will take ownership of
 		// alerts
 		if fh.StenosisConnector != nil && e.EventType == types.EventTypeAlert {
 			fh.StenosisConnector.Accept(e)
 		} else {
-			jsonCopy, err := json.Marshal(ev)
-			if err != nil {
-				return err
-			}
-			fh.ForwardEventChan <- jsonCopy
+			fh.ForwardEventChan <- []byte(e.JSONLine)
 			fh.Lock.Lock()
 			fh.PerfStats.ForwardedPerSec++
 			fh.Lock.Unlock()

--- a/processing/ip_handler.go
+++ b/processing/ip_handler.go
@@ -29,31 +29,35 @@ func MakeIPAlertEntryForHit(e types.Entry, matchedIP string,
 
 	newEntry := e
 	newEntry.EventType = "alert"
-	l, err := jsonparser.Set([]byte(newEntry.JSONLine), []byte("\"alert\""), "event_type")
-	if err != nil {
+
+	if l, err := jsonparser.Set([]byte(newEntry.JSONLine),
+		[]byte(`"alert"`), "event_type"); err != nil {
 		log.Warning(err)
 	} else {
 		newEntry.JSONLine = string(l)
 	}
-	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte("\"allowed\""), "alert", "action")
-	if err != nil {
+
+	if l, err := jsonparser.Set([]byte(newEntry.JSONLine),
+		[]byte(`"allowed"`), "alert", "action"); err != nil {
 		log.Warning(err)
 	} else {
 		newEntry.JSONLine = string(l)
 	}
-	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte("\"Potentially Bad Traffic\""), "alert", "category")
-	if err != nil {
+
+	if l, err := jsonparser.Set([]byte(newEntry.JSONLine),
+		[]byte(`"Potentially Bad Traffic"`), "alert", "category"); err != nil {
 		log.Warning(err)
 	} else {
 		newEntry.JSONLine = string(l)
 	}
-	signature, err := util.EscapeJSON(fmt.Sprintf(sig, alertPrefix, matchedIP, matchedNetString))
-	if err != nil {
+
+	if signature, err := util.EscapeJSON(fmt.Sprintf(sig, alertPrefix,
+		matchedIP, matchedNetString)); err != nil {
 		log.Warning(err)
 
 	} else {
-		l, err = jsonparser.Set([]byte(newEntry.JSONLine), signature, "alert", "signature")
-		if err != nil {
+		if l, err := jsonparser.Set([]byte(newEntry.JSONLine), signature,
+			"alert", "signature"); err != nil {
 			log.Warning(err)
 		} else {
 			newEntry.JSONLine = string(l)

--- a/processing/ip_handler.go
+++ b/processing/ip_handler.go
@@ -23,7 +23,7 @@ import (
 // as well as its timestamp.
 func MakeIPAlertEntryForHit(e types.Entry, matchedIP string,
 	rangerEntry cidranger.RangerEntry, alertPrefix string) types.Entry {
-	sig := "\"%s Communication involving IP %s in listed range %s\""
+	sig := `%s Communication involving IP %s in listed range %s`
 	matchedNet := rangerEntry.Network()
 	matchedNetString := matchedNet.String()
 
@@ -47,11 +47,17 @@ func MakeIPAlertEntryForHit(e types.Entry, matchedIP string,
 	} else {
 		newEntry.JSONLine = string(l)
 	}
-	l, err = jsonparser.Set([]byte(newEntry.JSONLine), []byte(fmt.Sprintf(sig, alertPrefix, matchedIP, matchedNetString)), "alert", "signature")
+	signature, err := util.EscapeJSON(fmt.Sprintf(sig, alertPrefix, matchedIP, matchedNetString))
 	if err != nil {
 		log.Warning(err)
+
 	} else {
-		newEntry.JSONLine = string(l)
+		l, err = jsonparser.Set([]byte(newEntry.JSONLine), signature, "alert", "signature")
+		if err != nil {
+			log.Warning(err)
+		} else {
+			newEntry.JSONLine = string(l)
+		}
 	}
 
 	return newEntry

--- a/processing/ip_handler_test.go
+++ b/processing/ip_handler_test.go
@@ -1,7 +1,7 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2018, DCSO GmbH
+// Copyright (c) 2018, 2020, DCSO GmbH
 
 import (
 	"bufio"
@@ -40,6 +40,9 @@ func makeIPHTTPEvent(srcip string, dstip string) types.Entry {
 		HTTPMethod: "GET",
 	}
 	eve := types.EveEvent{
+		Timestamp: &types.SuriTime{
+			Time: time.Now(),
+		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
 		SrcPort:   int(e.SrcPort),
@@ -74,7 +77,6 @@ func (h *IPCollectorHandler) GetEventTypes() []string {
 }
 
 func (h *IPCollectorHandler) Consume(e *types.Entry) error {
-	log.Info(e.JSONLine)
 	match := reIPmsg.FindStringSubmatch(e.JSONLine)
 	if match != nil {
 		h.Entries = append(h.Entries, e.JSONLine)
@@ -135,6 +137,16 @@ func TestIPHandler(t *testing.T) {
 	if len(fwhandler.Entries) < 2 {
 		t.Fatalf("expected %d forwarded BLF alerts, seen less (%d)", 2,
 			len(fwhandler.Entries))
+	}
+
+	var i interface{}
+	err := json.Unmarshal([]byte(fwhandler.Entries[0]), &i)
+	if err != nil {
+		t.Fatalf("could not unmarshal JSON: %s", err.Error())
+	}
+	err = json.Unmarshal([]byte(fwhandler.Entries[1]), &i)
+	if err != nil {
+		t.Fatalf("could not unmarshal JSON: %s", err.Error())
 	}
 }
 
@@ -203,6 +215,15 @@ func TestIPHandlerFromFile(t *testing.T) {
 			len(fwhandler.Entries))
 	}
 
+	var i interface{}
+	err = json.Unmarshal([]byte(fwhandler.Entries[0]), &i)
+	if err != nil {
+		t.Fatalf("could not unmarshal JSON: %s", err.Error())
+	}
+	err = json.Unmarshal([]byte(fwhandler.Entries[1]), &i)
+	if err != nil {
+		t.Fatalf("could not unmarshal JSON: %s", err.Error())
+	}
 }
 
 func TestIPHandlerFromFileInvalidFormat(t *testing.T) {

--- a/processing/ip_handler_test.go
+++ b/processing/ip_handler_test.go
@@ -41,7 +41,7 @@ func makeIPHTTPEvent(srcip string, dstip string) types.Entry {
 	}
 	eve := types.EveEvent{
 		Timestamp: &types.SuriTime{
-			Time: time.Now(),
+			Time: time.Now().UTC(),
 		},
 		EventType: e.EventType,
 		SrcIP:     e.SrcIP,
@@ -139,12 +139,13 @@ func TestIPHandler(t *testing.T) {
 			len(fwhandler.Entries))
 	}
 
-	var i interface{}
-	err := json.Unmarshal([]byte(fwhandler.Entries[0]), &i)
+	// check that the result is indeed valid JSON again
+	var result interface{}
+	err := json.Unmarshal([]byte(fwhandler.Entries[0]), &result)
 	if err != nil {
 		t.Fatalf("could not unmarshal JSON: %s", err.Error())
 	}
-	err = json.Unmarshal([]byte(fwhandler.Entries[1]), &i)
+	err = json.Unmarshal([]byte(fwhandler.Entries[1]), &result)
 	if err != nil {
 		t.Fatalf("could not unmarshal JSON: %s", err.Error())
 	}

--- a/processing/rdns_handler.go
+++ b/processing/rdns_handler.go
@@ -1,14 +1,16 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2019, DCSO GmbH
+// Copyright (c) 2019, 2020, DCSO GmbH
 
 import (
+	"fmt"
 	"net"
 	"sync"
 
 	"github.com/DCSO/fever/types"
 	"github.com/DCSO/fever/util"
+	"github.com/buger/jsonparser"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/yl2chen/cidranger"
@@ -71,7 +73,9 @@ func (a *RDNSHandler) Consume(e *types.Entry) error {
 			if !a.PrivateRangesOnly || isPrivate {
 				res, err = a.HostNamer.GetHostname(e.SrcIP)
 				if err == nil {
-					e.SrcHosts = res
+					for i, v := range res {
+						jsonparser.Set([]byte(e.JSONLine), []byte(v), "src_host", fmt.Sprintf("[%d]", i))
+					}
 				}
 			}
 		} else {
@@ -88,7 +92,9 @@ func (a *RDNSHandler) Consume(e *types.Entry) error {
 			if !a.PrivateRangesOnly || isPrivate {
 				res, err = a.HostNamer.GetHostname(e.DestIP)
 				if err == nil {
-					e.DestHosts = res
+					for i, v := range res {
+						jsonparser.Set([]byte(e.JSONLine), []byte(v), "dest_host", fmt.Sprintf("[%d]", i))
+					}
 				}
 			}
 		} else {

--- a/processing/rdns_handler_test.go
+++ b/processing/rdns_handler_test.go
@@ -1,0 +1,106 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2020, DCSO GmbH
+
+import (
+	"encoding/json"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/DCSO/fever/types"
+	log "github.com/sirupsen/logrus"
+)
+
+type MockHostNamer struct{}
+
+func (m *MockHostNamer) GetHostname(ipAddr string) ([]string, error) {
+	return []string{"foo.bar", "foo.baz"}, nil
+}
+
+func (m *MockHostNamer) Flush() {}
+
+func makeRDNSEvent() types.Entry {
+	e := types.Entry{
+		SrcIP:     "8.8.8.8",
+		SrcPort:   int64(rand.Intn(60000) + 1025),
+		DestIP:    "8.8.8.8",
+		DestPort:  53,
+		Timestamp: time.Now().Format(types.SuricataTimestampFormat),
+		EventType: "http",
+		Proto:     "TCP",
+	}
+	eve := types.EveEvent{
+		Timestamp: &types.SuriTime{
+			Time: time.Now(),
+		},
+		EventType: e.EventType,
+		SrcIP:     e.SrcIP,
+		SrcPort:   int(e.SrcPort),
+		DestIP:    e.DestIP,
+		DestPort:  int(e.DestPort),
+		Proto:     e.Proto,
+	}
+	json, err := json.Marshal(eve)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		e.JSONLine = string(json)
+	}
+	return e
+}
+
+type SrcHostResponse struct {
+	Evidence []struct {
+		Hostname string `json:"rdns"`
+	} `json:"src_host"`
+}
+
+type DstHostResponse struct {
+	Evidence []struct {
+		Hostname string `json:"rdns"`
+	} `json:"dest_host"`
+}
+
+func TestRDNSHandler(t *testing.T) {
+	hn := MockHostNamer{}
+	rdnsh := MakeRDNSHandler(&hn)
+
+	e := makeRDNSEvent()
+
+	err := rdnsh.Consume(&e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var srchosts SrcHostResponse
+	err = json.Unmarshal([]byte(e.JSONLine), &srchosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(srchosts.Evidence) != 2 {
+		t.Fatalf("src hosts length is not 2: length %d", len(srchosts.Evidence))
+	}
+	if srchosts.Evidence[0].Hostname != "foo.bar" {
+		t.Fatalf("wrong hostname:%s", srchosts.Evidence[0].Hostname)
+	}
+	if srchosts.Evidence[1].Hostname != "foo.baz" {
+		t.Fatalf("wrong hostname:%s", srchosts.Evidence[1].Hostname)
+	}
+
+	var desthosts DstHostResponse
+	err = json.Unmarshal([]byte(e.JSONLine), &desthosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(desthosts.Evidence) != 2 {
+		t.Fatalf("dest hosts length is not 2: length %d", len(desthosts.Evidence))
+	}
+	if desthosts.Evidence[0].Hostname != "foo.bar" {
+		t.Fatalf("wrong hostname:%s", desthosts.Evidence[0].Hostname)
+	}
+	if desthosts.Evidence[1].Hostname != "foo.baz" {
+		t.Fatalf("wrong hostname:%s", desthosts.Evidence[1].Hostname)
+	}
+}

--- a/processing/stenosis_connector.go
+++ b/processing/stenosis_connector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DCSO/fever/stenosis/api"
 	"github.com/DCSO/fever/stenosis/task"
 	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
 	"github.com/buger/jsonparser"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc"
@@ -98,9 +99,13 @@ func MakeStenosisConnector(endpoint string, timeout, timeBracket time.Duration,
 				for _, a := range myAlerts {
 					// annotate alerts with tokens and forward
 					if len(outParsed.Token) > 0 {
+						escToken, err := util.EscapeJSON(outParsed.Token)
+						if err != nil {
+							log.Warningf("cannot escape Stenosis token: %s", outParsed.Token)
+							continue
+						}
 						tmpLine, err := jsonparser.Set([]byte(a.JSONLine),
-							[]byte(fmt.Sprintf("\"%s\"", outParsed.Token)),
-							"_extra", "stenosis-info", "token")
+							escToken, "_extra", "stenosis-info", "token")
 						if err != nil {
 							log.Warningf("error adding Stenosis token: %s", err.Error())
 						} else {

--- a/processing/stenosis_connector.go
+++ b/processing/stenosis_connector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DCSO/fever/stenosis/api"
 	"github.com/DCSO/fever/stenosis/task"
 	"github.com/DCSO/fever/types"
+	"github.com/buger/jsonparser"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -95,32 +96,20 @@ func MakeStenosisConnector(endpoint string, timeout, timeBracket time.Duration,
 				}
 			} else if forwardChan != nil {
 				for _, a := range myAlerts {
-					var ev types.EveOutEvent
-					// annotate alerts with flows and forward
-					err := json.Unmarshal([]byte(a.JSONLine), &ev)
-					if err != nil {
-						// There's really not much we can do here. This
-						// case is highly unlikely since the JSON here
-						// comes from Suricata EVE (so not untrusted).
-						// In the unlikely case let's just log this and
-						// at least handle with the next alerts.
-						log.Error(err)
-						continue
-					}
-					if ev.ExtraInfo == nil {
-						ev.ExtraInfo = &types.ExtraInfo{
-							StenosisInfo: outParsed,
+					// annotate alerts with tokens and forward
+					if len(outParsed.Token) > 0 {
+						tmpLine, err := jsonparser.Set([]byte(a.JSONLine),
+							[]byte(fmt.Sprintf("\"%s\"", outParsed.Token)),
+							"_extra", "stenosis-info", "token")
+						if err != nil {
+							log.Warningf("error adding Stenosis token: %s", err.Error())
+						} else {
+							a.JSONLine = string(tmpLine)
 						}
 					} else {
-						ev.ExtraInfo.StenosisInfo = outParsed
+						log.Warning("empty token encountered")
 					}
-					var jsonCopy []byte
-					jsonCopy, err = json.Marshal(ev)
-					if err != nil {
-						log.Error(err)
-						continue
-					}
-					forwardChan <- jsonCopy
+					forwardChan <- []byte(a.JSONLine)
 				}
 			}
 			sConn.Cache.Delete(flow.FlowID)
@@ -162,7 +151,7 @@ func (s *StenosisConnector) Accept(e *types.Entry) {
 	s.Cache.Set(e.FlowID, myAlerts, cache.DefaultExpiration)
 }
 
-func (s *StenosisConnector) submit(e *types.Entry) (interface{}, error) {
+func (s *StenosisConnector) submit(e *types.Entry) (*api.QueryResponse, error) {
 	var ev types.EveOutEvent
 	if err := json.Unmarshal([]byte(e.JSONLine), &ev); err != nil {
 		return nil, err

--- a/processing/stenosis_connector_aux_test.go
+++ b/processing/stenosis_connector_aux_test.go
@@ -30,11 +30,11 @@ type mockGRPCServerOptionFunc func(*mockGRPCServer)
 
 type mockGRPCServerTokenGenFunc func(*task.Query) string
 
-func mockGRPCServerFailOption(meth string, err error) mockGRPCServerOptionFunc {
-	return func(m *mockGRPCServer) {
-		m.failWith[meth] = err
-	}
-}
+//func mockGRPCServerFailOption(meth string, err error) mockGRPCServerOptionFunc {
+//	return func(m *mockGRPCServer) {
+//		m.failWith[meth] = err
+//	}
+//}
 
 func mockGRPCServerDefaultTokenGen(query *task.Query) string {
 	switch query.GetType() {

--- a/processing/stenosis_connector_aux_test.go
+++ b/processing/stenosis_connector_aux_test.go
@@ -1,5 +1,8 @@
 package processing
 
+// DCSO FEVER
+// Copyright (c) 2020, DCSO GmbH
+
 import (
 	"context"
 	"fmt"
@@ -16,9 +19,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// DCSO FEVER
-// Copyright (c) 2020, DCSO GmbH
-
 const (
 	mockGRPCServerMethNewMockGRPCServer = "newMockGRPCServer"
 	mockGRPCServerMethAlive             = "Alive"
@@ -29,12 +29,6 @@ const (
 type mockGRPCServerOptionFunc func(*mockGRPCServer)
 
 type mockGRPCServerTokenGenFunc func(*task.Query) string
-
-//func mockGRPCServerFailOption(meth string, err error) mockGRPCServerOptionFunc {
-//	return func(m *mockGRPCServer) {
-//		m.failWith[meth] = err
-//	}
-//}
 
 func mockGRPCServerDefaultTokenGen(query *task.Query) string {
 	switch query.GetType() {

--- a/util/consumer.go
+++ b/util/consumer.go
@@ -142,13 +142,13 @@ func (c *Consumer) Shutdown() error {
 	return <-c.done
 }
 
-const MAX_LOG_LEN = 100
+const maxLogLen = 100
 
 func handle(deliveries <-chan wabbit.Delivery, done chan error, callback func(wabbit.Delivery)) {
 	for d := range deliveries {
 		v := d.Body()
-		if len(v) > MAX_LOG_LEN {
-			v = v[:MAX_LOG_LEN]
+		if len(v) > maxLogLen {
+			v = v[:maxLogLen]
 		}
 		log.Debugf(
 			"got %dB delivery: [%v] %q",

--- a/util/hostnamer.go
+++ b/util/hostnamer.go
@@ -1,51 +1,8 @@
 package util
 
-import (
-	"net"
-	"strings"
-	"sync"
-	"time"
-
-	"github.com/patrickmn/go-cache"
-)
-
-// HostNamer is a component that provides cached hostnames for IP
-// addresses passed as strings.
-type HostNamer struct {
-	Cache *cache.Cache
-	Lock  sync.Mutex
-}
-
-// NewHostNamer returns a new HostNamer with the given default expiration time.
-// Data entries will be purged after each cleanupInterval.
-func NewHostNamer(defaultExpiration, cleanupInterval time.Duration) *HostNamer {
-	return &HostNamer{
-		Cache: cache.New(defaultExpiration, cleanupInterval),
-	}
-}
-
-// GetHostname returns a list of host names for a given IP address.
-func (n *HostNamer) GetHostname(ipAddr string) ([]string, error) {
-	n.Lock.Lock()
-	defer n.Lock.Unlock()
-
-	val, found := n.Cache.Get(ipAddr)
-	if found {
-		return val.([]string), nil
-	}
-	hns, err := net.LookupAddr(ipAddr)
-	if err != nil {
-		return nil, err
-	}
-	for i, hn := range hns {
-		hns[i] = strings.TrimRight(hn, ".")
-	}
-	n.Cache.Set(ipAddr, hns, cache.DefaultExpiration)
-	val = hns
-	return val.([]string), nil
-}
-
-// Flush clears the cache of a HostNamer.
-func (n *HostNamer) Flush() {
-	n.Cache.Flush()
+// HostNamer is an interface specifying a component that provides
+// cached hostnames for IP addresses passed as strings.
+type HostNamer interface {
+	GetHostname(ipAddr string) ([]string, error)
+	Flush()
 }

--- a/util/hostnamer_rdns.go
+++ b/util/hostnamer_rdns.go
@@ -12,24 +12,24 @@ import (
 // HostNamerRDNS is a component that provides cached hostnames for IP
 // addresses passed as strings, determined via reverse DNS lookups.
 type HostNamerRDNS struct {
-	Cache *cache.Cache
-	Lock  sync.Mutex
+	cache *cache.Cache
+	lock  sync.Mutex
 }
 
 // NewHostNamerRDNS returns a new HostNamer with the given default expiration time.
 // Data entries will be purged after each cleanupInterval.
 func NewHostNamerRDNS(defaultExpiration, cleanupInterval time.Duration) *HostNamerRDNS {
 	return &HostNamerRDNS{
-		Cache: cache.New(defaultExpiration, cleanupInterval),
+		cache: cache.New(defaultExpiration, cleanupInterval),
 	}
 }
 
 // GetHostname returns a list of host names for a given IP address.
 func (n *HostNamerRDNS) GetHostname(ipAddr string) ([]string, error) {
-	n.Lock.Lock()
-	defer n.Lock.Unlock()
+	n.lock.Lock()
+	defer n.lock.Unlock()
 
-	val, found := n.Cache.Get(ipAddr)
+	val, found := n.cache.Get(ipAddr)
 	if found {
 		return val.([]string), nil
 	}
@@ -40,12 +40,12 @@ func (n *HostNamerRDNS) GetHostname(ipAddr string) ([]string, error) {
 	for i, hn := range hns {
 		hns[i] = strings.TrimRight(hn, ".")
 	}
-	n.Cache.Set(ipAddr, hns, cache.DefaultExpiration)
+	n.cache.Set(ipAddr, hns, cache.DefaultExpiration)
 	val = hns
 	return val.([]string), nil
 }
 
 // Flush clears the cache of a HostNamerRDNS.
 func (n *HostNamerRDNS) Flush() {
-	n.Cache.Flush()
+	n.cache.Flush()
 }

--- a/util/hostnamer_rdns.go
+++ b/util/hostnamer_rdns.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// HostNamerRDNS is a component that provides cached hostnames for IP
+// addresses passed as strings, determined via reverse DNS lookups.
+type HostNamerRDNS struct {
+	Cache *cache.Cache
+	Lock  sync.Mutex
+}
+
+// NewHostNamerRDNS returns a new HostNamer with the given default expiration time.
+// Data entries will be purged after each cleanupInterval.
+func NewHostNamerRDNS(defaultExpiration, cleanupInterval time.Duration) *HostNamerRDNS {
+	return &HostNamerRDNS{
+		Cache: cache.New(defaultExpiration, cleanupInterval),
+	}
+}
+
+// GetHostname returns a list of host names for a given IP address.
+func (n *HostNamerRDNS) GetHostname(ipAddr string) ([]string, error) {
+	n.Lock.Lock()
+	defer n.Lock.Unlock()
+
+	val, found := n.Cache.Get(ipAddr)
+	if found {
+		return val.([]string), nil
+	}
+	hns, err := net.LookupAddr(ipAddr)
+	if err != nil {
+		return nil, err
+	}
+	for i, hn := range hns {
+		hns[i] = strings.TrimRight(hn, ".")
+	}
+	n.Cache.Set(ipAddr, hns, cache.DefaultExpiration)
+	val = hns
+	return val.([]string), nil
+}
+
+// Flush clears the cache of a HostNamerRDNS.
+func (n *HostNamerRDNS) Flush() {
+	n.Cache.Flush()
+}

--- a/util/hostnamer_rdns_test.go
+++ b/util/hostnamer_rdns_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func _TestHostNamerQuad8(t *testing.T, ip string) {
-	hn := NewHostNamer(5*time.Second, 5*time.Second)
+	hn := NewHostNamerRDNS(5*time.Second, 5*time.Second)
 	v, err := hn.GetHostname(ip)
 	if err != nil {
 		log.Info(err)
@@ -49,7 +49,7 @@ func TestHostNamerQuad8v6(t *testing.T) {
 }
 
 func TestHostNamerInvalid(t *testing.T) {
-	hn := NewHostNamer(5*time.Second, 5*time.Second)
+	hn := NewHostNamerRDNS(5*time.Second, 5*time.Second)
 	_, err := hn.GetHostname("8.")
 	if err == nil {
 		t.Fatal("missed error")

--- a/util/submitter_amqp.go
+++ b/util/submitter_amqp.go
@@ -1,7 +1,7 @@
 package util
 
 // DCSO FEVER
-// Copyright (c) 2017, 2018, 2019, DCSO GmbH
+// Copyright (c) 2017, 2020, DCSO GmbH
 
 import (
 	"bytes"
@@ -219,7 +219,7 @@ func (s *AMQPSubmitter) SubmitWithHeaders(rawData []byte, key string, contentTyp
 
 // Finish cleans up the AMQP connection (reference counted).
 func (s *AMQPSubmitter) Finish() {
-	s.Submitter.Logger.Debugf("finishing submitter %v -> %v", s, s.Submitter)
+	s.Submitter.Logger.Debugf("finishing submitter %s (%s)", s.Submitter.URL, s.Target)
 	if s.Submitter.NofSubmitters == 1 {
 		close(s.Submitter.StopReconnection)
 		if s.Submitter.Verbose {

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,7 @@ package util
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -47,6 +48,15 @@ var evekeys = [][]string{
 	[]string{"dns", "version"},         // 20
 	[]string{"dns", "answers"},         // 21
 	[]string{"flow_id"},                // 22
+}
+
+// EscapeJSON escapes a string as a quoted byte slice for direct use in jsonparser.Set().
+func EscapeJSON(i string) ([]byte, error) {
+	b, err := json.Marshal(i)
+	if err != nil {
+		return []byte(""), err
+	}
+	return b, nil
 }
 
 // ParseJSON extracts relevant fields from an EVE JSON entry into an Entry struct.


### PR DESCRIPTION
This PR addresses #54 by avoiding the use of JSON marshaling when handling EVE-JSON received from Suricata. Consistent use of marshaling would require that a full schema of the Suricata version that is deployed is known to and updated in FEVER at all times, otherwise one would risk dropping data that is in the input but not present in the schema.
The proposed new implementation always uses `buger/jsonparser`'s `Set` function to add or modify fields in the original EVE-JSON, for example when creating an alert from a metadata event. Tests still finish successfully.

To check for the correctness of these modifications, I have also added unit tests for the reverse DNS enricher, which have been missing so far. To do that I had to refactor `HostNamer` into an interface to allow more flexible dependency injection, making it possible to use a mock `HostNamer` to test properly in situations where one cannot rely on proper Internet access.
In addition, I addressed some `golint` issues about constant naming and fixed a race condition caused by a debug output call.