### PR TITLE
Make test for malformed JSON marshaling more robust

### DIFF
--- a/processing/context_shipper_amqp_test.go
+++ b/processing/context_shipper_amqp_test.go
@@ -127,7 +127,7 @@ func TestContextShipperAMQPBrokenJSON(t *testing.T) {
 	if !found {
 		var entryStrings bytes.Buffer
 		for i, entry := range entries {
-			entryStrings.WriteString(fmt.Sprintf("(%d: %s)", i, entry.Message))
+			entryStrings.WriteString(fmt.Sprintf("%03d: %s\n", i, entry.Message))
 		}
 		t.Fatalf("malformed JSON error message not found: %v", entryStrings.String())
 	}

--- a/processing/context_shipper_amqp_test.go
+++ b/processing/context_shipper_amqp_test.go
@@ -1,7 +1,7 @@
 package processing
 
 // DCSO FEVER
-// Copyright (c) 2019, DCSO GmbH
+// Copyright (c) 2019, 2020, DCSO GmbH
 
 import (
 	"bytes"

--- a/processing/context_shipper_amqp_test.go
+++ b/processing/context_shipper_amqp_test.go
@@ -4,6 +4,8 @@ package processing
 // Copyright (c) 2019, DCSO GmbH
 
 import (
+	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -113,7 +115,20 @@ func TestContextShipperAMQPBrokenJSON(t *testing.T) {
 	}
 
 	close(inChan)
-	if entries[0].Message != `could not marshal event JSON: {""value":1}` {
-		t.Fatalf("wrong error message: %v", entries[0].Message)
+	found := false
+
+	for _, entry := range entries {
+		if entry.Message == `could not marshal event JSON: {""value":1}` {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		var entryStrings bytes.Buffer
+		for i, entry := range entries {
+			entryStrings.WriteString(fmt.Sprintf("(%d: %s)", i, entry.Message))
+		}
+		t.Fatalf("malformed JSON error message not found: %v", entryStrings.String())
 	}
 }


### PR DESCRIPTION
We've seen a failing unit test checking for the presence of an error message where the order of the messages was not as expected in the tests. However, the order actually does not matter in the tests, the test in question is only supposed to check for the _existence_ of an message in a list. Hence the original test condition was too restrictive. This PR relaxes this test to search for the expected message in a list instead of just assuming it is the first one in the list.