### PR TITLE
make Stenosis interface selectable

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -213,10 +213,11 @@ func mainfunc(cmd *cobra.Command, args []string) {
 			stenosisTimeout := viper.GetDuration("stenosis.submission-timeout")
 			stenosisCacheExpiry := viper.GetDuration("stenosis.cache-expiry")
 			stenosisURL := viper.GetString("stenosis.submission-url")
+			stenosisIface := viper.GetString("stenosis.interface")
 
 			if err := fh.EnableStenosis(stenosisURL,
 				stenosisTimeout, stenosisTimeBracket, flowNotifyChan, stenosisCacheExpiry,
-				tlsConfig); err != nil {
+				tlsConfig, stenosisIface); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -660,6 +661,8 @@ func init() {
 	viper.BindPFlag("stenosis.submission-timeout", runCmd.PersistentFlags().Lookup("stenosis-submission-timeout"))
 	runCmd.PersistentFlags().DurationP("stenosis-cache-expiry", "", 30*time.Minute, "alert cache expiry timeout")
 	viper.BindPFlag("stenosis.cache-expiry", runCmd.PersistentFlags().Lookup("stenosis-cache-expiry"))
+	runCmd.PersistentFlags().StringP("stenosis-interface", "", "*", "interface to watch events for")
+	viper.BindPFlag("stenosis.interface", runCmd.PersistentFlags().Lookup("stenosis-interface"))
 
 	// Bloom filter alerting options
 	runCmd.PersistentFlags().StringP("bloom-file", "b", "", "Bloom filter for external indicator screening")

--- a/fever.yaml
+++ b/fever.yaml
@@ -95,6 +95,7 @@ stenosis:
   root-cas:
       - root.crt
   skipverify: false
+  # interface: "*"
 
 # Extra fields to add to each forwarded event.
 #add-fields:

--- a/types/entry.go
+++ b/types/entry.go
@@ -40,4 +40,5 @@ type Entry struct {
 	PktsToClient  int64
 	PktsToServer  int64
 	FlowID        string
+	Iface         string
 }

--- a/util/util.go
+++ b/util/util.go
@@ -48,6 +48,7 @@ var evekeys = [][]string{
 	[]string{"dns", "version"},         // 20
 	[]string{"dns", "answers"},         // 21
 	[]string{"flow_id"},                // 22
+	[]string{"in_iface"},               // 23
 }
 
 // EscapeJSON escapes a string as a quoted byte slice for direct use in jsonparser.Set().
@@ -227,6 +228,12 @@ func ParseJSON(json []byte) (e types.Entry, parseerr error) {
 			}
 		case 22:
 			e.FlowID, err = jsonparser.ParseString(value)
+			if err != nil {
+				parseerr = err
+				return
+			}
+		case 23:
+			e.Iface, err = jsonparser.ParseString(value)
 			if err != nil {
 				parseerr = err
 				return

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -27,6 +27,7 @@ var entries = []types.Entry{
 		DNSRCode:  "NOERROR",
 		DNSRData:  "10.0.0.12",
 		DNSType:   "answer",
+		Iface:     "enp2s0f1",
 		FlowID:    "4711",
 	},
 	types.Entry{
@@ -41,6 +42,7 @@ var entries = []types.Entry{
 		HTTPHost:   "api.icndb.com",
 		HTTPUrl:    `/jokes/random?firstName=Chuck&lastName=Norris&limitTo=[nerdy]`,
 		HTTPMethod: `GET`,
+		Iface:      "enp2s0f1",
 		FlowID:     "2323",
 	},
 	types.Entry{
@@ -55,6 +57,7 @@ var entries = []types.Entry{
 		HTTPHost:   "foobar",
 		HTTPUrl:    `/scripts/wpnbr.dll`,
 		HTTPMethod: `POST`,
+		Iface:      "enp2s0f1",
 		FlowID:     "2134",
 	},
 }


### PR DESCRIPTION
This PR adds a new `--stenosis-interface` parameter and corresponding setting in the config file. If set, it limits the Stenosis interaction to alerts coming from the specified interface. The default is `"*"`, which stands for any interface.
Closes #60.