### PR TITLE
Bugfix bundle

### DIFF
--- a/processing/stenosis_connector.go
+++ b/processing/stenosis_connector.go
@@ -86,12 +86,16 @@ func MakeStenosisConnector(endpoint string, timeout, timeBracket time.Duration,
 			log.Debugf("flow with existing alert finished: %v", flow)
 			myAlerts = aval.([]types.Entry)
 			outParsed, err := sConn.submit(&flow)
-			if err != nil {
+			if err != nil || outParsed == nil {
 				// We had a problem contacting stenosis for tokens.
 				// Let's make sure that alerts are forwarded
 				// nevertheless -- their delivery has highest
 				// priority.
-				log.Error(err)
+				if err != nil {
+					log.Error(err)
+				} else {
+					log.Error("could not obtain token but no error was raised")
+				}
 				for _, a := range myAlerts {
 					forwardChan <- []byte(a.JSONLine)
 				}


### PR DESCRIPTION
This PR addresses some issues that were found in the latest FEVER version:
- Segfault in Stenosis connector (#63), addressed by more defensive programming around values that could be `nil`
- Segfault in AMQP submitter (#64), addressed by more defensive programming around values that could be `nil` and extra mutex protection
- Missing unlock for a mutex in `TestFlowExtractor()`, essentially blocking effective testing with `go test -race` by causing a deadlock and timeout