### PR TITLE
Add flow profiler

### DIFF
--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -126,6 +126,18 @@ func mainfunc(cmd *cobra.Command, args []string) {
 			evp.Stop(c)
 			<-c
 		}()
+		flp, err := processing.MakeFlowProfiler(30*time.Second, statssubmitter)
+		if err != nil {
+			log.Fatal(err)
+
+		}
+		dispatcher.RegisterHandler(flp)
+		flp.Run()
+		defer func() {
+			c := make(chan bool)
+			flp.Stop(c)
+			<-c
+		}()
 	}
 
 	// Configure forwarding

--- a/processing/flow_profiler.go
+++ b/processing/flow_profiler.go
@@ -1,0 +1,148 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2020, DCSO GmbH
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+	log "github.com/sirupsen/logrus"
+)
+
+// ProtoProfile contains flow statistics for a give app layer protocol.
+type ProtoProfile struct {
+	PacketsToSrv uint64
+	PacketsToClt uint64
+	BytesToSrv   uint64
+	BytesToClt   uint64
+}
+
+// FlowProfiler counts EVE event type statistics, such as number and size
+// of JSON data received from the input.
+type FlowProfiler struct {
+	SensorID      string
+	Host          string
+	Profile       map[string]ProtoProfile
+	FlushPeriod   time.Duration
+	ProfileMutex  sync.Mutex
+	CloseChan     chan bool
+	ClosedChan    chan bool
+	Logger        *log.Entry
+	Submitter     util.StatsSubmitter
+	SubmitChannel chan []byte
+}
+
+// MakeFlowProfiler creates a new FlowProfiler.
+func MakeFlowProfiler(flushPeriod time.Duration, submitter util.StatsSubmitter) (*FlowProfiler, error) {
+	a := &FlowProfiler{
+		FlushPeriod: flushPeriod,
+		Logger: log.WithFields(log.Fields{
+			"domain": "flowprofiler",
+		}),
+		Profile:       make(map[string]ProtoProfile),
+		CloseChan:     make(chan bool),
+		ClosedChan:    make(chan bool),
+		SubmitChannel: make(chan []byte, 60),
+		Submitter:     submitter,
+	}
+	a.Host = getFQDN()
+	return a, nil
+}
+
+func (a *FlowProfiler) formatLineProtocol() []string {
+	out := make([]string, 0)
+	a.ProfileMutex.Lock()
+	myProfile := a.Profile
+	for proto, protoVals := range myProfile {
+		out = append(out, fmt.Sprintf("%s,host=%s,proto=%s flowbytestoclient=%d,flowbytestoserver=%d,flowpktstoclient=%d,flowpktstoserver=%d %d",
+			util.ToolName, a.Host, proto,
+			protoVals.BytesToClt, protoVals.BytesToSrv,
+			protoVals.PacketsToClt, protoVals.PacketsToSrv,
+			uint64(time.Now().UnixNano())))
+		a.Profile[proto] = ProtoProfile{}
+	}
+	a.ProfileMutex.Unlock()
+	return out
+}
+
+func (a *FlowProfiler) flush() {
+	lineStrings := a.formatLineProtocol()
+	for _, lineString := range lineStrings {
+		select {
+		case a.SubmitChannel <- []byte(lineString):
+			break
+		default:
+			log.Warning("channel is full, cannot submit message...")
+		}
+	}
+}
+
+// Consume processes an Entry, adding the data within to the internal
+// aggregated state
+func (a *FlowProfiler) Consume(e *types.Entry) error {
+	aproto := e.AppProto
+	if aproto == "" {
+		aproto = "unknown"
+	}
+	a.ProfileMutex.Lock()
+	profile := a.Profile[aproto]
+	profile.BytesToClt += uint64(e.BytesToClient)
+	profile.BytesToSrv += uint64(e.BytesToServer)
+	profile.PacketsToClt += uint64(e.PktsToClient)
+	profile.PacketsToSrv += uint64(e.PktsToServer)
+	a.Profile[aproto] = profile
+	a.ProfileMutex.Unlock()
+	return nil
+}
+
+// Run starts the background aggregation service for this handler
+func (a *FlowProfiler) Run() {
+	go func() {
+		for message := range a.SubmitChannel {
+			a.Submitter.SubmitWithHeaders(message, "", "text/plain", map[string]string{
+				"database":         "telegraf",
+				"retention_policy": "default",
+			})
+		}
+	}()
+	go func() {
+		i := 0 * time.Second
+		for {
+			select {
+			case <-a.CloseChan:
+				close(a.SubmitChannel)
+				close(a.ClosedChan)
+				return
+			default:
+				if i >= a.FlushPeriod {
+					a.flush()
+					i = 0 * time.Second
+				}
+				time.Sleep(1 * time.Second)
+				i += 1 * time.Second
+			}
+		}
+	}()
+}
+
+// Stop causes the aggregator to cease aggregating and submitting data
+func (a *FlowProfiler) Stop(stopChan chan bool) {
+	close(a.CloseChan)
+	<-a.ClosedChan
+	close(stopChan)
+}
+
+// GetName returns the name of the handler
+func (a *FlowProfiler) GetName() string {
+	return "Flow profiler"
+}
+
+// GetEventTypes returns a slice of event type strings that this handler
+// should be applied to
+func (a *FlowProfiler) GetEventTypes() []string {
+	return []string{"flow"}
+}

--- a/processing/flow_profiler_test.go
+++ b/processing/flow_profiler_test.go
@@ -1,0 +1,155 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2020, DCSO GmbH
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DCSO/fever/types"
+)
+
+const (
+	numOfProfiledFlowItems = 10000
+)
+
+func makeFlowProfilerEvent() types.Entry {
+	e := types.Entry{
+		SrcIP:         fmt.Sprintf("10.0.0.%d", rand.Intn(250)),
+		SrcPort:       []int64{1, 2, 3, 4, 5}[rand.Intn(5)],
+		DestIP:        fmt.Sprintf("10.0.0.%d", rand.Intn(250)),
+		DestPort:      []int64{11, 12, 13, 14, 15}[rand.Intn(5)],
+		Timestamp:     time.Now().Format(types.SuricataTimestampFormat),
+		EventType:     "flow",
+		Proto:         "TCP",
+		AppProto:      []string{"foo", "bar", "baz"}[rand.Intn(3)],
+		BytesToClient: int64(rand.Intn(10000)),
+		BytesToServer: int64(rand.Intn(10000)),
+		PktsToClient:  int64(rand.Intn(100)),
+		PktsToServer:  int64(rand.Intn(100)),
+	}
+	jsonBytes, _ := json.Marshal(e)
+	e.JSONLine = string(jsonBytes)
+	return e
+}
+
+type flowProfilerTestSubmitter struct {
+	sync.Mutex
+	Values [][]byte
+}
+
+func (fpts *flowProfilerTestSubmitter) SubmitWithHeaders(rawData []byte, key string, contentType string, myHeaders map[string]string) {
+	fpts.Lock()
+	defer fpts.Unlock()
+	fpts.Values = append(fpts.Values, rawData)
+}
+
+func (fpts *flowProfilerTestSubmitter) Submit(rawData []byte, key string, contentType string) {
+	fpts.Lock()
+	defer fpts.Unlock()
+	fpts.Values = append(fpts.Values, rawData)
+}
+
+func (fpts *flowProfilerTestSubmitter) UseCompression() {
+	// pass
+}
+
+func (fpts *flowProfilerTestSubmitter) Finish() {
+	// pass
+}
+
+func TestFlowProfiler(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	myMap := make(map[string]ProtoProfile)
+	seenProfile := make(map[string]ProtoProfile)
+
+	feedWaitChan := make(chan bool)
+
+	s := &flowProfilerTestSubmitter{
+		Values: make([][]byte, 0),
+	}
+
+	f, err := MakeFlowProfiler(1*time.Second, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Run()
+
+	for i := 0; i < numOfProfiledFlowItems; i++ {
+		ev := makeFlowProfilerEvent()
+		myProfile := myMap[ev.AppProto]
+		myProfile.BytesToClt += uint64(ev.BytesToClient)
+		myProfile.BytesToSrv += uint64(ev.BytesToServer)
+		myProfile.PacketsToClt += uint64(ev.PktsToClient)
+		myProfile.PacketsToSrv += uint64(ev.PktsToServer)
+		myMap[ev.AppProto] = myProfile
+		f.Consume(&ev)
+	}
+
+	go func() {
+		r := regexp.MustCompile(`proto=(?P<Proto>[^ ]+) flowbytestoclient=(?P<fbtc>[0-9]+),flowbytestoserver=(?P<fbts>[0-9]+),flowpktstoclient=(?P<fptc>[0-9]+),flowpktstoserver=(?P<fpts>[0-9]+)`)
+		for {
+			s.Lock()
+			found := 0
+			for _, v := range s.Values {
+				for _, proto := range []string{"foo", "bar", "baz"} {
+					if strings.Contains(string(v), fmt.Sprintf("proto=%s flowbytestoclient=0,flowbytestoserver=0,flowpktstoclient=0,flowpktstoserver=0", proto)) {
+						found++
+					}
+				}
+			}
+			s.Unlock()
+			if found == 3 {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		s.Lock()
+		for _, v := range s.Values {
+			sm := r.FindStringSubmatch(string(v))
+			if sm == nil {
+				continue
+			}
+			p := seenProfile[sm[1]]
+			intV, err := strconv.ParseUint(sm[2], 10, 64)
+			if err == nil {
+				p.BytesToClt += intV
+			}
+			intV, err = strconv.ParseUint(sm[3], 10, 64)
+			if err == nil {
+				p.BytesToSrv += intV
+			}
+			intV, err = strconv.ParseUint(sm[4], 10, 64)
+			if err == nil {
+				p.PacketsToClt += intV
+			}
+			intV, err = strconv.ParseUint(sm[5], 10, 64)
+			if err == nil {
+				p.PacketsToSrv += intV
+			}
+			seenProfile[sm[1]] = p
+		}
+		s.Unlock()
+		close(feedWaitChan)
+	}()
+
+	<-feedWaitChan
+
+	consumeWaitChan := make(chan bool)
+	f.Stop(consumeWaitChan)
+	<-consumeWaitChan
+
+	if !reflect.DeepEqual(myMap, seenProfile) {
+		t.Fatal("different result for test")
+	}
+}

--- a/processing/flow_profiler_test.go
+++ b/processing/flow_profiler_test.go
@@ -67,6 +67,10 @@ func (fpts *flowProfilerTestSubmitter) Finish() {
 	// pass
 }
 
+// TestFlowProfiler checks whether flow profiles are generated correctly.
+// To do this, it consumes a set of example events with randomized event types
+// and sizes, generates a reference set of statistics and then compares it to
+// the values submitted to a test submitter which simply stores these values.
 func TestFlowProfiler(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 	myMap := make(map[string]ProtoProfile)

--- a/types/entry.go
+++ b/types/entry.go
@@ -41,4 +41,5 @@ type Entry struct {
 	PktsToServer  int64
 	FlowID        string
 	Iface         string
+	AppProto      string
 }

--- a/util/util.go
+++ b/util/util.go
@@ -49,6 +49,7 @@ var evekeys = [][]string{
 	[]string{"dns", "answers"},         // 21
 	[]string{"flow_id"},                // 22
 	[]string{"in_iface"},               // 23
+	[]string{"app_proto"},              // 24
 }
 
 // EscapeJSON escapes a string as a quoted byte slice for direct use in jsonparser.Set().
@@ -234,6 +235,12 @@ func ParseJSON(json []byte) (e types.Entry, parseerr error) {
 			}
 		case 23:
 			e.Iface, err = jsonparser.ParseString(value)
+			if err != nil {
+				parseerr = err
+				return
+			}
+		case 24:
+			e.AppProto, err = jsonparser.ParseString(value)
 			if err != nil {
 				parseerr = err
 				return

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -43,6 +43,7 @@ var entries = []types.Entry{
 		HTTPUrl:    `/jokes/random?firstName=Chuck&lastName=Norris&limitTo=[nerdy]`,
 		HTTPMethod: `GET`,
 		Iface:      "enp2s0f1",
+		AppProto:   "http",
 		FlowID:     "2323",
 	},
 	types.Entry{


### PR DESCRIPTION
This PR introduces a _flow profiler_ component which continuously submits a stream of InfluxDB lines to the metrics endpoint, stating aggregated flow volumes per EVE flow `app_proto` field, i.e. `http`, `tls`, `dns`, ...

Example:
```
fever,host=myserver,proto=tls flowbytestoclient=333736002,flowbytestoserver=331630352,flowpktstoclient=3300537,flowpktstoserver=3306617 1604331118355294893
fever,host=myserver,proto=http flowbytestoclient=335222181,flowbytestoserver=333353797,flowpktstoclient=3319996,flowpktstoserver=3312692 1604331118355324326
fever,host=myserver,proto=dns flowbytestoclient=332768109,flowbytestoserver=332023930,flowpktstoclient=3280898,flowpktstoserver=3301838 1604331118355326782
```