### PR TITLE
add heartbeat injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Flags:
   -f, --flushtime duration                       time interval for event aggregation (default 1m0s)
   -T, --fwd-all-types                            forward all event types
   -t, --fwd-event-types strings                  event types to forward to socket (default [alert,stats])
+      --heartbeat-enable                         Forward HTTP heartbeat event
+      --heartbeat-times strings                  Times of day to send heartbeat (list of 24h HH:MM strings)
   -h, --help                                     help for run
   -r, --in-redis string                          Redis input server (assumes "suricata" list key, no pwd)
       --in-redis-nopipe                          do not use Redis pipelining
@@ -81,6 +83,7 @@ Flags:
       --stenosis-client-chain-file string        certificate file for Stenosis TLS connection (default "stenosis.crt")
       --stenosis-client-key-file string          key file for Stenosis TLS connection (default "stenosis.key")
       --stenosis-enable                          notify Stenosis instance on alert
+      --stenosis-interface string                interface to watch events for (default "*")
       --stenosis-root-cas strings                root certificate(s) for TLS connection to stenosis (default [root.crt])
       --stenosis-skipverify                      skip TLS certificate verification
       --stenosis-submission-timeout duration     timeout for connecting to Stenosis (default 5s)

--- a/fever.yaml
+++ b/fever.yaml
@@ -101,6 +101,13 @@ stenosis:
 #add-fields:
 #  sensor-id: foobar
 
+# Send 'heartbeat' HTTP event
+heartbeat:
+  enable: false
+  # 24h HH:MM strings with local times to send heartbeat
+  times:
+    - "00:01"
+
 # Configuration for detailed flow metadata submission.
 flowextract:
   enable: false

--- a/processing/heartbeat_injector.go
+++ b/processing/heartbeat_injector.go
@@ -1,0 +1,131 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2020, DCSO GmbH
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"time"
+
+	"github.com/DCSO/fever/types"
+	"github.com/DCSO/fever/util"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// match 24 hour local time string, separated by colon
+	injectTimeRegex = regexp.MustCompile(`^(([01][0-9])|(2[0-3])):[0-5][0-9]$`)
+	// We pick this value as a tick interval to check the time against the list
+	// of times to send heartbeats at. We check once per minute as that is the
+	// resolution of the specified times as well.
+	injectTimeCheckTick = 1 * time.Minute
+)
+
+// HeartbeatInjector regularly adds a date-based pseudo-event to the forwarded
+// event stream.
+type HeartbeatInjector struct {
+	SensorID       string
+	Times          []string
+	CloseChan      chan bool
+	Logger         *log.Entry
+	ForwardHandler Handler
+}
+
+// MakeHeartbeatInjector creates a new HeartbeatInjector.
+func MakeHeartbeatInjector(forwardHandler Handler, injectTimes []string) (*HeartbeatInjector, error) {
+	sensorID, err := util.GetSensorID()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range injectTimes {
+		if !injectTimeRegex.Match([]byte(v)) {
+			return nil, fmt.Errorf("invalid time specification in heartbeat injector config: '%s'", v)
+		}
+	}
+	a := &HeartbeatInjector{
+		ForwardHandler: forwardHandler,
+		Logger: log.WithFields(log.Fields{
+			"domain": "heartbeat_injector",
+		}),
+		Times:     injectTimes,
+		CloseChan: make(chan bool),
+		SensorID:  sensorID,
+	}
+	return a, nil
+}
+
+func makeHeartbeatEvent() types.Entry {
+	now := time.Now()
+	entry := types.Entry{
+		SrcIP:     "192.0.2.1",
+		SrcPort:   int64(rand.Intn(60000) + 1025),
+		DestIP:    "192.0.2.2",
+		DestPort:  80,
+		Timestamp: time.Now().Format(types.SuricataTimestampFormat),
+		EventType: "http",
+		Proto:     "TCP",
+		HTTPHost: fmt.Sprintf("test-%d-%02d-%02d.vast",
+			now.Year(), now.Month(), now.Day()),
+		HTTPUrl:    "/just-visiting",
+		HTTPMethod: "GET",
+	}
+	eve := types.EveEvent{
+		Timestamp: &types.SuriTime{
+			Time: time.Now().UTC(),
+		},
+		EventType: entry.EventType,
+		SrcIP:     entry.SrcIP,
+		SrcPort:   int(entry.SrcPort),
+		DestIP:    entry.DestIP,
+		DestPort:  int(entry.DestPort),
+		Proto:     entry.Proto,
+		HTTP: &types.HTTPEvent{
+			Hostname:        entry.HTTPHost,
+			URL:             entry.HTTPUrl,
+			HTTPMethod:      entry.HTTPMethod,
+			HTTPUserAgent:   "FEVER",
+			Status:          200,
+			Protocol:        "HTTP/1.1",
+			Length:          42,
+			HTTPContentType: "text/html",
+		},
+	}
+	json, err := json.Marshal(eve)
+	if err != nil {
+		log.Warn(err)
+	} else {
+		entry.JSONLine = string(json)
+	}
+	return entry
+}
+
+// Run starts the background service.
+func (a *HeartbeatInjector) Run() {
+	go func() {
+		for {
+			select {
+			case <-a.CloseChan:
+				return
+			default:
+				curTime := time.Now().Format("15:04")
+				for _, timeVal := range a.Times {
+					if curTime == timeVal {
+						ev := makeHeartbeatEvent()
+						a.Logger.Debugf("creating heartbeat event for %s: %s",
+							curTime, string(ev.JSONLine))
+						a.ForwardHandler.Consume(&ev)
+					}
+				}
+				time.Sleep(injectTimeCheckTick)
+			}
+		}
+	}()
+}
+
+// Stop causes the service to cease the background work.
+func (a *HeartbeatInjector) Stop() {
+	close(a.CloseChan)
+}

--- a/processing/heartbeat_injector_test.go
+++ b/processing/heartbeat_injector_test.go
@@ -1,0 +1,84 @@
+package processing
+
+// DCSO FEVER
+// Copyright (c) 2020, DCSO GmbH
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DCSO/fever/types"
+
+	"github.com/buger/jsonparser"
+)
+
+type HeartbeatTestFwdHandler struct {
+	Entries []types.Entry
+	Lock    sync.Mutex
+}
+
+func (h *HeartbeatTestFwdHandler) Consume(e *types.Entry) error {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+	h.Entries = append(h.Entries, *e)
+	return nil
+}
+
+func (h *HeartbeatTestFwdHandler) GetEventTypes() []string {
+	return []string{"*"}
+}
+
+func (h *HeartbeatTestFwdHandler) GetName() string {
+	return "Heartbeat Injector Forwarding Test Handler"
+}
+
+func TestHeartbeatInjectorInvalidTime(t *testing.T) {
+	hbth := HeartbeatTestFwdHandler{
+		Entries: make([]types.Entry, 0),
+	}
+
+	_, err := MakeHeartbeatInjector(&hbth, []string{"foo"})
+	if err == nil {
+		t.Fatal("invalid time not caught")
+	}
+}
+
+func TestHeartbeatInjector(t *testing.T) {
+	hbth := HeartbeatTestFwdHandler{
+		Entries: make([]types.Entry, 0),
+	}
+
+	now := time.Now()
+	ctime := []string{now.Format("15:04")}
+
+	hbi, err := MakeHeartbeatInjector(&hbth, ctime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hbi.Run()
+	for {
+		hbth.Lock.Lock()
+		if len(hbth.Entries) > 0 {
+			hbth.Lock.Unlock()
+			break
+		}
+		hbth.Lock.Unlock()
+		time.Sleep(100 * time.Millisecond)
+	}
+	hbi.Stop()
+
+	hbJSON := hbth.Entries[0].JSONLine
+
+	expectedHost := fmt.Sprintf("test-%d-%02d-%02d.vast",
+		now.Year(), now.Month(), now.Day())
+	seenHost, err := jsonparser.GetString([]byte(hbJSON), "http", "hostname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seenHost != expectedHost {
+		t.Fatalf("wrong hostname for heartbeat: %s", seenHost)
+	}
+}


### PR DESCRIPTION
This PR introduces a new component that regularly injects fake pseudo-events into the forward EVE stream at specified times. These can be used, for instance, to monitor and test downstream processing pipelines and larger data workflows. This version here injects an HTTP event with a time-specific `http.hostname` field, containing the current day:
```json
{
    "timestamp": "2020-12-03T09:36:58.871586+0000",
    "event_type": "http",
    "src_ip": "192.0.2.1",
    "src_port": 8912,
    "dest_ip": "192.0.2.2",
    "dest_port": 80,
    "proto": "TCP",
    "http": {
        "hostname": "test-2020-12-03.vast",
        "url": "/just-visiting",
        "http_user_agent": "FEVER",
        "http_content_type": "text/html",
        "http_method": "GET",
        "protocol": "HTTP/1.1",
        "status": 200,
        "length": 42
    }
}
```

IP addresses are taken from RFC 5737 reserved spaces to reduce the chance of interfering with real observations.