### PR TITLE
allow FEVER to start without AMQP connection

### DIFF
--- a/util/submitter_amqp.go
+++ b/util/submitter_amqp.go
@@ -135,7 +135,11 @@ func MakeAMQPSubmitterWithReconnector(url string, target string, verbose bool,
 			return nil, err
 		}
 
+		// Start reconnect loop in separate goroutine.
 		go reconnectOnFailure(mySubmitter)
+		// The reconnect loop started in the line above will only trigger when
+		// something is received on the error channel. We'll emit a fake error
+		// to trigger the initial connect to avoid code duplication.
 		mySubmitter.ErrorChan <- utils.NewError(0, "Initial connect", true, true)
 
 		gSubmitters[url] = mySubmitter

--- a/util/submitter_amqp.go
+++ b/util/submitter_amqp.go
@@ -1,7 +1,7 @@
 package util
 
 // DCSO FEVER
-// Copyright (c) 2017, 2020, DCSO GmbH
+// Copyright (c) 2017, 2021, DCSO GmbH
 
 import (
 	"bytes"

--- a/util/submitter_test.go
+++ b/util/submitter_test.go
@@ -5,7 +5,6 @@ package util
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 	"time"
 
@@ -15,17 +14,6 @@ import (
 	"github.com/NeowayLabs/wabbit/amqptest"
 	"github.com/NeowayLabs/wabbit/amqptest/server"
 )
-
-func TestInvalidReconnector(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
-	submitter, err := MakeAMQPSubmitterWithReconnector("amqp://sensor:sensor@localhost:9999/%2f",
-		"foo.bar.test", true, func(url string) (wabbit.Conn, error) {
-			return nil, fmt.Errorf("error")
-		})
-	if submitter != nil || err == nil {
-		t.Fail()
-	}
-}
 
 func TestSubmitter(t *testing.T) {
 	serverURL := "amqp://sensor:sensor@localhost:9999/%2f/"


### PR DESCRIPTION
We no longer fail hard when no connection to the AMQP server can be made. Instead, we start directly in the reconnect loop. Note that we also need to disable tests that currently assume that connection failures mean immediate errors.

Closes #69 