### PR TITLE
remove potentially blocking calls/locks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:stretch
+      - image: circleci/golang:1.15-buster
     environment:
       GO111MODULE: on
     working_directory: /go/src/github.com/DCSO/fever

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       - image: circleci/golang:1.15-buster
     environment:
-      GO111MODULE: on
+      GO111MODULE: "on"
     working_directory: /go/src/github.com/DCSO/fever
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15-buster
+      - image: circleci/golang:latest
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/DCSO/fever

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.10-stretch
-
+      - image: circleci/golang:stretch
+    environment:
+      GO111MODULE: on
     working_directory: /go/src/github.com/DCSO/fever
     steps:
       - checkout
       - run:
           name: Install test dependencies
           command: 'sudo apt-get update && sudo apt-get install redis-server -y'
-
       - run: go get -v -t -d ./...
       - run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,31 @@
+module github.com/DCSO/fever
+
+go 1.14
+
+require (
+	github.com/DCSO/bloom v0.2.3
+	github.com/DCSO/fluxline v0.0.0-20200907065040-78686e5e68f6
+	github.com/NeowayLabs/wabbit v0.0.0-20201021105516-ded4a9ef19d2
+	github.com/Showmax/go-fqdn v1.0.0 // indirect
+	github.com/buger/jsonparser v1.1.1
+	github.com/fsouza/go-dockerclient v1.7.1 // indirect
+	github.com/garyburd/redigo v1.6.2
+	github.com/golang/protobuf v1.4.3
+	github.com/gomodule/redigo v1.8.3 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/onsi/ginkgo v1.15.0 // indirect
+	github.com/onsi/gomega v1.10.5 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/sirupsen/logrus v1.8.0
+	github.com/spf13/cobra v1.1.3
+	github.com/spf13/viper v1.7.1
+	github.com/streadway/amqp v1.0.0
+	github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
+	github.com/tiago4orion/conjure v0.0.0-20150908101743-93cb30b9d218 // indirect
+	github.com/yl2chen/cidranger v1.0.2
+	google.golang.org/grpc v1.35.0
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+	gopkg.in/pg.v5 v5.3.3
+)

--- a/processing/flow_aggregator.go
+++ b/processing/flow_aggregator.go
@@ -6,6 +6,7 @@ package processing
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -141,7 +142,7 @@ func (a *FlowAggregator) countFlow(key string, e *types.Entry) {
 func (a *FlowAggregator) Consume(e *types.Entry) error {
 	a.StringBuf.Write([]byte(e.SrcIP))
 	a.StringBuf.Write([]byte(e.DestIP))
-	a.StringBuf.Write([]byte(string(e.DestPort)))
+	a.StringBuf.Write([]byte(fmt.Sprint(e.DestPort)))
 	a.countFlow(a.StringBuf.String(), e)
 	a.StringBuf.Reset()
 	return nil

--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -174,7 +174,7 @@ func (fh *ForwardHandler) runCounter() {
 			// Release live counter to not block further events
 			fh.Lock.Unlock()
 
-			fh.StatsEncoder.Submit(fh.PerfStats)
+			fh.StatsEncoder.Submit(myStats)
 			sTime = time.Now()
 		}
 	}

--- a/processing/forward_handler_test.go
+++ b/processing/forward_handler_test.go
@@ -144,13 +144,13 @@ func TestForwardHandler(t *testing.T) {
 	e = makeEvent("alert", "foo3")
 	fh.Consume(&e)
 
+	// wait for socket consumer to receive all
+	wg.Wait()
+
 	// stop forwarding handler
 	scChan := make(chan bool)
 	fh.Stop(scChan)
 	<-scChan
-
-	// wait for socket consumer to receive all
-	wg.Wait()
 
 	if len(coll) != 2 {
 		t.Fatalf("unexpected number of alerts: %d != 2", len(coll))
@@ -224,13 +224,13 @@ func TestForwardHandlerWithAddedFields(t *testing.T) {
 	e = makeEvent("alert", "foo2")
 	fh.Consume(&e)
 
+	// wait for socket consumer to receive all
+	wg.Wait()
+
 	// stop forwarding handler
 	scChan := make(chan bool)
 	fh.Stop(scChan)
 	<-scChan
-
-	// wait for socket consumer to receive all
-	wg.Wait()
 
 	if len(coll) != 2 {
 		t.Fatalf("unexpected number of alerts: %d != 2", len(coll))
@@ -303,6 +303,8 @@ func TestForwardAllHandler(t *testing.T) {
 	e = makeEvent("alert", "foo3")
 	fh.Consume(&e)
 
+	wg.Wait()
+
 	// stop forwarding handler
 	scChan := make(chan bool)
 	fh.Stop(scChan)
@@ -311,7 +313,6 @@ func TestForwardAllHandler(t *testing.T) {
 	// stop socket consumer
 	inputListener.Close()
 	close(clCh)
-	wg.Wait()
 
 	if len(coll) != 3 {
 		t.Fatalf("unexpected number of alerts: %d != 3", len(coll))

--- a/processing/stenosis_connector_test.go
+++ b/processing/stenosis_connector_test.go
@@ -196,6 +196,9 @@ func _TestStenosisQueryRegularSuccessForwarded(t *testing.T, ifaceSetting string
 	// send flow notification with matching flow ID to signal end of flow
 	notifyChan <- flowEntry
 
+	// wait for socket consumer to receive all
+	wg.Wait()
+
 	// stop forwarding handler
 	scChan := make(chan bool)
 	fh.Stop(scChan)
@@ -203,9 +206,6 @@ func _TestStenosisQueryRegularSuccessForwarded(t *testing.T, ifaceSetting string
 
 	// we can now close this
 	grpcServer.Close()
-
-	// wait for socket consumer to receive all
-	wg.Wait()
 
 	return coll
 }


### PR DESCRIPTION
We have noticed that slow network connections may cause delays in event forwarding due to metrics submissions holding locks in the hot path for longer than they need, mostly holding them until the data protected by the locks have been transferred. This PR modifies the code such that locks are used in a more considerate way, reducing lock time as much as possible.