### PR TITLE
add version subcommand

### DIFF
--- a/cmd/fever/cmds/version.go
+++ b/cmd/fever/cmds/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	version = "1.0.17"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show FEVER version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Currently there is no way to determine the version of an installed `fever` executable without looking at the packaging. It would be useful to include a command that shows the version on request.

FYI: I am aware that one could automate the version assignment by generating Go code using version information from another source, like using git tags. However, I am respecting distribution channels that do not use Git, like Debian, where everything is done via tarballs. So the choice to code the version number into the tool code is deliberate -- it will just need to be increased on release.