### PR TITLE
unlock earlier to prevent deadlock on reconnect

### DIFF
--- a/processing/forward_handler.go
+++ b/processing/forward_handler.go
@@ -126,16 +126,16 @@ func (fh *ForwardHandler) runForward() {
 						_, err = fh.OutputConn.Write(item)
 						if err != nil {
 							fh.OutputConn.Close()
+							fh.Lock.Unlock()
 							log.Warn(err)
 							fh.ReconnectNotifyChan <- true
-							fh.Lock.Unlock()
 							continue
 						}
 						_, err = fh.OutputConn.Write([]byte("\n"))
 						if err != nil {
 							fh.OutputConn.Close()
-							log.Warn(err)
 							fh.Lock.Unlock()
+							log.Warn(err)
 							continue
 						}
 					}


### PR DESCRIPTION
This PR ensures that the mutex protecting the `OutputConn` in the forwarding handler is released before pushing a reconnect request on an unbuffered channel, without giving the code a chance to return for unlocking.