### PR TITLE
Reduce log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to FEVER will be documented in this file.
 
 ## [1.0.19] - TBD
 
+### Added
+- Support Bloom filter matching for TLS fingerprints (#76, #38)
+
+### Changed
+- Reduce log noise by moving AMQP messages to debug log level (#78)
 
 ## [1.0.18] - 2020-03-30
 

--- a/processing/dns_aggregator.go
+++ b/processing/dns_aggregator.go
@@ -107,10 +107,9 @@ func (a *DNSAggregator) flush() {
 	a.Logger.WithFields(log.Fields{
 		"agg_dns": a.PerfStats.DNSAggregateCount,
 		"in_dns":  a.PerfStats.DNSAggregateRawCount,
-	}).Info("flushing events")
+	}).Debug("flushing events")
 	for _, v := range myDNS {
 		jsonString, _ := json.Marshal(v)
-		//  log.Info(string(jsonString))
 		newEntry := types.Entry{
 			Timestamp: v.Timestamp[0],
 			EventType: v.EventType,

--- a/util/submitter_amqp.go
+++ b/util/submitter_amqp.go
@@ -227,7 +227,7 @@ func (s *AMQPSubmitter) SubmitWithHeaders(rawData []byte, key string, contentTyp
 		s.Submitter.Logger.WithFields(log.Fields{
 			"rawsize":     len(rawData),
 			"payloadsize": len(payload),
-		}).Infof("submission to %s:%s (%s) successful", s.Submitter.URL, s.Target, key)
+		}).Debugf("submission to %s:%s (%s) successful", s.Submitter.URL, s.Target, key)
 	}
 }
 


### PR DESCRIPTION
This PR moves some very noisy output (~95% of all FEVER output with little interesting information) to the DEBUG log level. 