### PR TITLE
Ensure that alertified events also contain added fields

### DIFF
--- a/cmd/fever/cmds/alertify.go
+++ b/cmd/fever/cmds/alertify.go
@@ -140,7 +140,11 @@ func alertify(cmd *cobra.Command, args []string) {
 	limit := viper.GetUint("alert-limit")
 	extrakey := viper.GetString("extra-key")
 
+	addFields := viper.GetStringMapString("add-fields")
 	a := makeAlertifyAlertifier(prefix, extrakey)
+	if err := a.SetAddedFields(addFields); err != nil {
+		log.Fatal(err)
+	}
 	for e := range eventChan {
 		err := emitAlertsForEvent(a, e, ioc, os.Stdout, uint64(limit))
 		if err != nil {

--- a/db/slurper_ejdb.go
+++ b/db/slurper_ejdb.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package db

--- a/util/add_fields_preprocess.go
+++ b/util/add_fields_preprocess.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// PreprocessAddedFields preprocesses the added fields to be able to only use
+// fast string operations to add them to JSON text later. This code
+// progressively builds a JSON snippet by adding JSON key-value pairs for each
+// added field, e.g. `, "foo":"bar"`.
+func PreprocessAddedFields(fields map[string]string) (string, error) {
+	j := ""
+	for k, v := range fields {
+		// Escape the fields to make sure we do not mess up the JSON when
+		// encountering weird symbols in field names or values.
+		kval, err := EscapeJSON(k)
+		if err != nil {
+			log.Warningf("cannot escape value: %s", v)
+			return "", err
+		}
+		vval, err := EscapeJSON(v)
+		if err != nil {
+			log.Warningf("cannot escape value: %s", v)
+			return "", err
+		}
+		j += fmt.Sprintf(",%s:%s", kval, vval)
+	}
+	// We finish the list of key-value pairs with a final brace:
+	// `, "foo":"bar"}`. This string can now just replace the final brace in a
+	// given JSON string. If there were no added fields, we just leave the
+	// output at the final brace.
+	j += "}"
+	return j, nil
+}

--- a/util/add_fields_preprocess_test.go
+++ b/util/add_fields_preprocess_test.go
@@ -1,0 +1,45 @@
+package util
+
+import "testing"
+
+func TestPreprocessAddedFields(t *testing.T) {
+	type args struct {
+		fields map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "empty fieldset",
+			args: args{
+				fields: map[string]string{},
+			},
+			want: "}",
+		},
+		{
+			name: "fieldset present",
+			args: args{
+				fields: map[string]string{
+					"foo": "bar",
+					"baz": "quux",
+				},
+			},
+			want: `,"foo":"bar","baz":"quux"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PreprocessAddedFields(tt.args.fields)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PreprocessAddedFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("PreprocessAddedFields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This addresses and closes #89 by ensuring that alerts output by `fever alertify` instead of the forwarder also contain added fields. The required preprocessing functionality has been refactored to be reusable in both contexts now.