### PR TITLE
remove null values from alertified JSON

### DIFF
--- a/cmd/fever/cmds/alertify.go
+++ b/cmd/fever/cmds/alertify.go
@@ -4,9 +4,11 @@ package cmd
 // Copyright (c) 2020, DCSO GmbH
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/DCSO/fever/input"
@@ -125,6 +127,39 @@ func emitAlertsForEvent(a *util.Alertifier, e types.Entry, ioc string,
 	return nil
 }
 
+func removeItemsWithNullValues(root map[string]interface{}, rootArr []interface{}) {
+	// Note we never have a call with both of these possibly set.
+	if root != nil {
+		rVal := reflect.ValueOf(root)
+		for _, k := range rVal.MapKeys() {
+			v := rVal.MapIndex(k)
+			if v.IsNil() {
+				delete(root, k.String())
+				continue
+			}
+			switch t := v.Interface().(type) {
+			// We support recursion into maps and slices.
+			case map[string]interface{}:
+				removeItemsWithNullValues(t, nil)
+			case []interface{}:
+				removeItemsWithNullValues(nil, t)
+			}
+		}
+	} else if rootArr != nil {
+		rVal := reflect.ValueOf(rootArr)
+		for i := 0; i < rVal.Len(); i++ {
+			v := rVal.Index(i)
+			switch t := v.Interface().(type) {
+			// We support recursion into maps and slices.
+			case map[string]interface{}:
+				removeItemsWithNullValues(t, nil)
+			case []interface{}:
+				removeItemsWithNullValues(nil, t)
+			}
+		}
+	}
+}
+
 func alertify(cmd *cobra.Command, args []string) {
 	eventChan := make(chan types.Entry, defaultQueueSize)
 
@@ -139,6 +174,7 @@ func alertify(cmd *cobra.Command, args []string) {
 	}
 	limit := viper.GetUint("alert-limit")
 	extrakey := viper.GetString("extra-key")
+	removeNulls := viper.GetBool("remove-nulls")
 
 	addFields := viper.GetStringMapString("add-fields")
 	a := makeAlertifyAlertifier(prefix, extrakey)
@@ -146,7 +182,23 @@ func alertify(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	for e := range eventChan {
-		err := emitAlertsForEvent(a, e, ioc, os.Stdout, uint64(limit))
+		var err error
+		var eJSON map[string]interface{}
+		if removeNulls {
+			err = json.Unmarshal([]byte(e.JSONLine), &eJSON)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			removeItemsWithNullValues(eJSON, nil)
+			fJSON, err := json.Marshal(eJSON)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			e.JSONLine = string(fJSON)
+		}
+		err = emitAlertsForEvent(a, e, ioc, os.Stdout, uint64(limit))
 		if err != nil {
 			log.Error(err)
 		}
@@ -174,4 +226,6 @@ func init() {
 	viper.BindPFlag("alert-prefix", alertifyCmd.PersistentFlags().Lookup("alert-prefix"))
 	alertifyCmd.PersistentFlags().UintP("alert-limit", "l", 0, "limit for alerts to be created (0 = no limit)")
 	viper.BindPFlag("alert-limit", alertifyCmd.PersistentFlags().Lookup("alert-limit"))
+	alertifyCmd.PersistentFlags().BoolP("remove-nulls", "n", true, "remove items with nulls")
+	viper.BindPFlag("remove-nulls", alertifyCmd.PersistentFlags().Lookup("remove-nulls"))
 }


### PR DESCRIPTION
This PR adds an additional `--remove-nulls` option to `fever alertify` that enables the removal of all fields in alertified JSON with a value of `null` -- such fields are often produced by VAST in the case of highly variable schemas for specific types where many fields may not always be present (e.g. here something like `suricata.dns`).