### PR TITLE
optionally submit testdata via pDNS channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,33 @@ To feed EVE data into FEVER using Redis (started with `-r`), you can simply LPUS
 $ head -n 100000 huge.eve.json | scripts/makelpush | redis-cli > /dev/null
 ```
 
+## End-to-end testing support
+
+FEVER can optionally inject in-band test data into downstream submissions, such as passive DNS observations, so allow automated checks that receiving components are updated correctly.
+
+*  For passive DNS observation submissions, use the `pdns.test-domain` config item to insert a dummy entry for that domain, e.g. for `pdns.tests-domain` set to `heartbeat.fever-heartbeat`:
+   ```json
+   {
+     "timestamp_start": "2021-12-07T18:18:00.029197078Z",
+     "timestamp_end": "2021-12-07T18:19:00.063460044Z",
+     "dns": {
+       "heartbeat.fever-heartbeat": {
+         "rdata": [
+           {
+             "answering_host": "0.0.0.0",
+             "rrtype": "A",
+             "rdata": "0.0.0.0",
+             "rcode": "NOERROR",
+             "count": 1
+           }
+         ]
+       },
+   ...
+     }
+   }
+   ```
+
+
 ## Author/Contact
 
 Sascha Steinbiss

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -391,6 +391,10 @@ func mainfunc(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+		testdomain := viper.GetString("pdns.test-domain")
+		if testdomain != "" {
+			pdc.EnableTestdataDomain(testdomain)
+		}
 		dispatcher.RegisterHandler(pdc)
 		pdc.Run()
 		defer func() {

--- a/fever.yaml
+++ b/fever.yaml
@@ -92,6 +92,9 @@ pdns:
   enable: true
   submission-url: amqp://guest:guest@localhost:5672/
   submission-exchange: pdns
+  # If test-domain is non-empty, add an extra A observation for this rrname to
+  # all submissions
+  #test-domain: heartbeat.fever-heartbeat
 
 # Configuration for alert-associated metadata submission.
 context:

--- a/util/add_fields_preprocess_test.go
+++ b/util/add_fields_preprocess_test.go
@@ -9,7 +9,7 @@ func TestPreprocessAddedFields(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    string
+		want    []string
 		wantErr bool
 	}{
 		{
@@ -17,7 +17,9 @@ func TestPreprocessAddedFields(t *testing.T) {
 			args: args{
 				fields: map[string]string{},
 			},
-			want: "}",
+			want: []string{
+				"}",
+			},
 		},
 		{
 			name: "fieldset present",
@@ -27,7 +29,10 @@ func TestPreprocessAddedFields(t *testing.T) {
 					"baz": "quux",
 				},
 			},
-			want: `,"foo":"bar","baz":"quux"}`,
+			want: []string{
+				`,"foo":"bar","baz":"quux"}`,
+				`,"baz":"quux","foo":"bar"}`,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -37,7 +42,14 @@ func TestPreprocessAddedFields(t *testing.T) {
 				t.Errorf("PreprocessAddedFields() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
+			found := false
+			for _, w := range tt.want {
+				if got == w {
+					found = true
+					break
+				}
+			}
+			if !found {
 				t.Errorf("PreprocessAddedFields() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This PR introduces a feature configurable via the new `test-domain` config entry in the `pdns` section:
```yaml
# Configuration for passive DNS submission.
pdns:
  enable: true
  submission-url: amqp://guest:guest@localhost:5672/
  submission-exchange: pdns
  # If test-domain is non-empty, add an extra `A` observation for this rrname to
  # all submissions
  test-domain: heartbeat.fever-heartbeat
```
which will cause an additional observation to be included with dummy data to each submission:
```json
{
  "timestamp_start": "2021-12-07T18:18:00.029197078Z",
  "timestamp_end": "2021-12-07T18:19:00.063460044Z",
  "dns": {
    "heartbeat.fever-heartbeat": {
      "rdata": [
        {
          "answering_host": "0.0.0.0",
          "rrtype": "A",
          "rdata": "0.0.0.0",
          "rcode": "NOERROR",
          "count": 1
        }
      ]
    },
...
  }
}
```
This can, for example, be used as a known present observation to implement in-band end-to-end monitoring in a production pipeline.