### PR TITLE
add testdata submission for flow reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ FEVER can optionally inject in-band test data into downstream submissions, such 
    }
    ```
    will be created and forwarded.
-*  For passive DNS observation submissions, use the `pdns.test-domain` config item to insert a dummy entry for that domain, e.g. for `pdns.tests-domain` set to `heartbeat.fever-heartbeat`:
+* For passive DNS observation submissions, use the `pdns.test-domain` config item to insert a dummy entry for that domain, e.g. for `pdns.test-domain` set to `heartbeat.fever-heartbeat`:
    ```json
    {
      "timestamp_start": "2021-12-07T18:18:00.029197078Z",
@@ -230,11 +230,34 @@ FEVER can optionally inject in-band test data into downstream submissions, such 
            }
          ]
        },
-   ...
+      ...
      }
    }
    ```
-
+*  For flow report submission, use the `flowreport.testdata*` config items to insert a dummy flow for that specific IPs and ports, e.g. for :
+   ```yaml
+   flowreport:
+     # ...
+     testdata-srcip: 0.0.0.1
+     testdata-destip: 0.0.0.2
+     testdata-destport: 99999
+   ```
+   we would get
+   ```json
+   {
+      "sensor-id": "XXX",
+      "time-start": "2021-12-08T13:53:36.442182896+01:00",
+      "time-end": "2021-12-08T13:53:46.490743527+01:00",
+      "tuples": {
+          "0.0.0.1_0.0.0.2_99999": {
+              "count": 1,
+              "total_bytes_toclient": 23,
+              "total_bytes_toserver": 42
+          }
+      },
+      ...
+   }
+   ```
 
 ## Author/Contact
 

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -441,6 +441,12 @@ func mainfunc(cmd *cobra.Command, args []string) {
 			}).Info("compression of flow stats")
 		}
 		ua := processing.MakeUnicornAggregator(submitter, unicornSleep, dummyMode)
+		testSrcIP := viper.GetString("flowreport.testdata-srcip")
+		testDestIP := viper.GetString("flowreport.testdata-destip")
+		testDestPort := viper.GetInt64("flowreport.testdata-destport")
+		if testSrcIP != "" && testDestIP != "" {
+			ua.EnableTestFlow(testSrcIP, testDestIP, testDestPort)
+		}
 		dispatcher.RegisterHandler(ua)
 		ua.Run()
 		defer func() {

--- a/fever.yaml
+++ b/fever.yaml
@@ -80,6 +80,11 @@ flowreport:
   submission-exchange: aggregations
   # Set to true to disable gzip compression for uploads.
   nocompress: false
+  # If both srcip and destip are non-empty, inject an extra flow record for
+  # these towards the given destination port.
+  #testdata-srcip: 0.0.0.1
+  #testdata-destip: 0.0.0.2
+  #testdata-destport: 99999
 
 # Configuration for metrics (i.e. InfluxDB) submission.
 metrics:

--- a/processing/unicorn_aggregator.go
+++ b/processing/unicorn_aggregator.go
@@ -137,7 +137,9 @@ func (a *UnicornAggregator) submit(submitter util.StatsSubmitter, dummyMode bool
 
 }
 
-// CountFlowTuple increments the flow tuple counter for the given key.
+// CountFlowTuple increments the flow tuple counter for the given key. If addCnt
+// is >1, then the caller is responsible for providing the correct (sub-total)
+// counts for bytestoclient and bytestoserver.
 func (a *UnicornAggregator) CountFlowTuple(key string, bytestoclient int64,
 	bytestoserver int64, addCnt int64) {
 	a.UnicornTuplesMutex.Lock()


### PR DESCRIPTION
 For flow report submission, use the `flowreport.testdata*` config items to insert a dummy flow for that specific IPs and ports, e.g. for :
   ```yaml
   flowreport:
     # ...
     testdata-srcip: 0.0.0.1
     testdata-destip: 0.0.0.2
     testdata-destport: 99999
   ```
   we would get
   ```json
   {
      "sensor-id": "XXX",
      "time-start": "2021-12-08T13:53:36.442182896+01:00",
      "time-end": "2021-12-08T13:53:46.490743527+01:00",
      "tuples": {
          "0.0.0.1_0.0.0.2_99999": {
              "count": 1,
              "total_bytes_toclient": 23,
              "total_bytes_toserver": 42
          }
      },
      ...
   }
   ```
