### PR TITLE
add alert heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,38 @@ $ head -n 100000 huge.eve.json | scripts/makelpush | redis-cli > /dev/null
 
 FEVER can optionally inject in-band test data into downstream submissions, such as passive DNS observations, so allow automated checks that receiving components are updated correctly.
 
+* For injecting test alerts into the forwarded stream, use the `heartbeat.alert-times` list to specify when an alert heartbeat should be injected. The approach is identical to the one for the general heartbeats: at each specified time, an alert like
+   ```json
+   {
+       "timestamp": "2021-12-09T09:49:35.641252+0000",
+       "event_type": "alert",
+       "src_ip": "192.0.2.1",
+       "src_port": 39106,
+       "dest_ip": "192.0.2.2",
+       "dest_port": 80,
+       "proto": "TCP",
+       "alert": {
+           "action": "allowed",
+           "gid": 0,
+           "signature_id": 0,
+           "rev": 0,
+           "signature": "DCSO FEVER TEST alert",
+           "category": "Not Suspicious Traffic",
+           "severity": 0
+       },
+       "http": {
+           "hostname": "test-2021-12-09.vast",
+           "url": "/just-visiting",
+           "http_user_agent": "FEVER",
+           "http_content_type": "text/html",
+           "http_method": "GET",
+           "protocol": "HTTP/1.1",
+           "status": 200,
+           "length": 42
+       }
+   }
+   ```
+   will be created and forwarded.
 *  For passive DNS observation submissions, use the `pdns.test-domain` config item to insert a dummy entry for that domain, e.g. for `pdns.tests-domain` set to `heartbeat.fever-heartbeat`:
    ```json
    {

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -513,8 +513,9 @@ func mainfunc(cmd *cobra.Command, args []string) {
 	// Heartbeat injector
 	enableHeartbeat := viper.GetBool("heartbeat.enable")
 	heartbeatTimes := viper.GetStringSlice("heartbeat.times")
+	heartbeatAlertTimes := viper.GetStringSlice("heartbeat.alert-times")
 	if enableHeartbeat {
-		hi, err := processing.MakeHeartbeatInjector(forwardHandler, heartbeatTimes)
+		hi, err := processing.MakeHeartbeatInjector(forwardHandler, heartbeatTimes, heartbeatAlertTimes)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/fever.yaml
+++ b/fever.yaml
@@ -121,12 +121,15 @@ stenosis:
 #add-fields:
 #  sensor-id: foobar
 
-# Send 'heartbeat' HTTP event
+# Send 'heartbeat' HTTP or alert event
 heartbeat:
   enable: false
-  # 24h HH:MM strings with local times to send heartbeat
+  # 24h HH:MM strings with local times to send heartbeat as HTTP event
   times:
     - "00:01"
+  # 24h HH:MM strings with local times to send heartbeat as alert
+  #alert-times:
+  #  - "00:02"
 
 # Configuration for detailed flow metadata submission.
 flowextract:


### PR DESCRIPTION
One can now use the `heartbeat.alert-times` list to specify when an alert heartbeat should be injected.
```yaml
heartbeat:
  enable: true
  # 24h HH:MM strings with local times to send heartbeat as HTTP event
  times:
    - "00:01"
  # 24h HH:MM strings with local times to send heartbeat as alert
  alert-times:
    - "00:02"
```

The approach is identical to the one for the general heartbeats: at each specified time, an alert like
   ```json
   {
       "timestamp": "2021-12-09T09:49:35.641252+0000",
       "event_type": "alert",
       "src_ip": "192.0.2.1",
       "src_port": 39106,
       "dest_ip": "192.0.2.2",
       "dest_port": 80,
       "proto": "TCP",
       "alert": {
           "action": "allowed",
           "gid": 0,
           "signature_id": 0,
           "rev": 0,
           "signature": "DCSO FEVER TEST alert",
           "category": "Not Suspicious Traffic",
           "severity": 0
       },
       "http": {
           "hostname": "test-2021-12-09.vast",
           "url": "/just-visiting",
           "http_user_agent": "FEVER",
           "http_content_type": "text/html",
           "http_method": "GET",
           "protocol": "HTTP/1.1",
           "status": 200,
           "length": 42
       }
   }
   ```
is generated and injected in to the stream of forwarded events.