### PR TITLE
fix parsing of JSON null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FEVER will be documented in this file.
 
+## [1.3.3] - 2022-01-25
+
+### Changed
+- Fixed handling of JSON `null` values (#97)
+
 ## [1.3.2] - 2021-12-09
 
 ### Added

--- a/util/testdata/jsonparse_eve_nulls.json
+++ b/util/testdata/jsonparse_eve_nulls.json
@@ -1,0 +1,1 @@
+{"timestamp":"2017-03-06T06:54:10.839668+0000","flow_id":null,"in_iface":"enp2s0f1","event_type":"fileinfo","vlan":null,"src_ip":null,"src_port":null,"dest_ip":null,"dest_port":null,"http":{"hostname":"api.icndb.com","url":null,"state":"CLOSED","md5":null}}

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ package util
 // Copyright (c) 2017, 2018, 2020, DCSO GmbH
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -71,6 +72,11 @@ func ParseJSON(json []byte) (e types.Entry, parseerr error) {
 		}
 		if err != nil {
 			parseerr = err
+			return
+		}
+		// skip null fields; these will not be handled by the low-level
+		// jsonparser.Parse* () functions
+		if bytes.Equal(value, []byte("null")) {
 			return
 		}
 		switch idx {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/DCSO/fever/types"
 )
 
+var nullEntry = types.Entry{
+	Timestamp: "2017-03-06T06:54:10.839668+0000",
+	EventType: "fileinfo",
+	JSONLine:  `{"timestamp":"2017-03-06T06:54:10.839668+0000","flow_id":null,"in_iface":"enp2s0f1","event_type":"fileinfo","vlan":null,"src_ip":null,"src_port":null,"dest_ip":null,"dest_port":null,"http":{"hostname":"api.icndb.com","url":null,"state":"CLOSED","md5":null}}`,
+	Iface:     "enp2s0f1",
+	HTTPHost:  "api.icndb.com",
+}
+
 var entries = []types.Entry{
 	types.Entry{
 		SrcIP:     "10.0.0.10",
@@ -124,6 +132,31 @@ func TestJSONParseEVEempty(t *testing.T) {
 	}
 	if i > 0 {
 		t.Fatal("empty file should not generate any entries")
+	}
+}
+
+func TestJSONParseEVEwithnull(t *testing.T) {
+	f, err := os.Open("testdata/jsonparse_eve_nulls.json")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	scanner := bufio.NewScanner(f)
+	i := 0
+	var entry types.Entry
+	for scanner.Scan() {
+		json := scanner.Bytes()
+		e, err := ParseJSON(json)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		entry = e
+		i++
+	}
+	if i != 1 {
+		t.Fatalf("should parse only one entry, got %d", i)
+	}
+	if !reflect.DeepEqual(nullEntry, entry) {
+		t.Fatalf("entry %d parsed from JSON does not match expected value", i)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug in the way FEVER currently handles incoming JSON fields that are `null` (not the string `"null"` but a JSON null value): These cause a parse error, as they are not handled correctly by the low-level `jsonparser.Parse*()` function used in the main JSON parser code. We need to explicitly check for those and skip them.

Note (for peace of mind) that this issue is not relevant for incoming Suricata EVE-JSON (as this will never set `null` fields) but only when handling EVE-JSON from other sources.