### PR TITLE
log heartbeat creation with Info level

### DIFF
--- a/processing/heartbeat_injector.go
+++ b/processing/heartbeat_injector.go
@@ -130,7 +130,7 @@ func (a *HeartbeatInjector) Run() {
 				for _, timeVal := range a.Times {
 					if curTime == timeVal {
 						ev := makeHeartbeatEvent("http")
-						a.Logger.Debugf("creating heartbeat event for %s: %s",
+						a.Logger.Infof("creating heartbeat HTTP event for %s: %s",
 							curTime, string(ev.JSONLine))
 						a.ForwardHandler.Consume(&ev)
 					}
@@ -138,7 +138,7 @@ func (a *HeartbeatInjector) Run() {
 				for _, timeVal := range a.AlertTimes {
 					if curTime == timeVal {
 						ev := makeHeartbeatEvent("alert")
-						a.Logger.Debugf("creating heartbeat event for %s: %s",
+						a.Logger.Infof("creating heartbeat alert event for %s: %s",
 							curTime, string(ev.JSONLine))
 						a.ForwardHandler.Consume(&ev)
 					}


### PR DESCRIPTION
This PR changes the log output for heartbeats from `Debug` to `Info`, also enabling outputs in regular production without enabling verbose output. Given the expected low volume of these logs this should be acceptable.
Closes #100.