### PR TITLE
fix issue with null values in DNS data

### DIFF
--- a/input/input_stdin.go
+++ b/input/input_stdin.go
@@ -1,7 +1,7 @@
 package input
 
 // DCSO FEVER
-// Copyright (c) 2020, DCSO GmbH
+// Copyright (c) 2020, 2023, DCSO GmbH
 
 import (
 	"bufio"
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// StdinInput is an Input reading JSON EVE input from a Unix socket.
+// StdinInput is an Input reading JSON EVE input from standard input.
 type StdinInput struct {
 	EventChan     chan types.Entry
 	Verbose       bool


### PR DESCRIPTION
When encountering a `null` JSON value in DNS v2 data, the JSON parser will error out and not process this data point. This PR fixes the issue by ignoring that kind of error and skipping this data point.