### PR TITLE
implement full flow aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to FEVER will be documented in this file.
 
+## [1.3.6] - 2024-07-03
+
+### Added
+- Add support for sending aggregations from all flows, not just TCP
+  bidirectional ones.
+
 ## [1.3.5] - 2023-03-27
 
 ### Fixed

--- a/cmd/fever/cmds/run.go
+++ b/cmd/fever/cmds/run.go
@@ -409,7 +409,9 @@ func mainfunc(cmd *cobra.Command, args []string) {
 				"state":  "disabled",
 			}).Info("compression of flow stats")
 		}
-		ua := processing.MakeUnicornAggregator(submitter, unicornSleep, dummyMode)
+		allFlows := viper.GetBool("flowreport.all")
+		ua := processing.MakeUnicornAggregator(submitter, unicornSleep, dummyMode,
+			allFlows)
 		testSrcIP := viper.GetString("flowreport.testdata-srcip")
 		testDestIP := viper.GetString("flowreport.testdata-destip")
 		testDestPort := viper.GetInt64("flowreport.testdata-destport")

--- a/fever.yaml
+++ b/fever.yaml
@@ -85,6 +85,8 @@ flowreport:
   #testdata-srcip: 0.0.0.1
   #testdata-destip: 0.0.0.2
   #testdata-destport: 99999
+  # Set to true to count _all_ flows, not just TCP bidirectional ones.
+  all: false
 
 # Configuration for metrics (i.e. InfluxDB) submission.
 metrics:


### PR DESCRIPTION
This PR adds support for counting and submitting _all_ flow aggregations, not just bidirectional TCP ones, as before. This behaviour can be enabled by setting the configuration item `flowreport.all` to `true`.